### PR TITLE
fix description for paper_code.md

### DIFF
--- a/paper_code.md
+++ b/paper_code.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: 
+description: why a code development model can be work to improve many types of papers
 ---
 # Paper writing as code development
 


### PR DESCRIPTION
partial fix to make not have the default site description be written on this page.  Not sure this is the description we want, but for now we need to have something.