### PR TITLE
Moved policies from journal_information repository

### DIFF
--- a/editorial_board.md
+++ b/editorial_board.md
@@ -1,11 +1,11 @@
-# Policies About the Editorial Boards
+# Policies About the Editorial Board
 
 These policies are currently a draft, and not yet in force.
 
-## Policies on Decisions
-Issues regarding governance structure, editorial board membership, leadership, and financial
-model must be decided by a 2/3 majority vote of the voting members of the editorial
-board.
+## Policies on Decisions Issues regarding governance structure,
+editorial board membership, leadership, and financial model must be
+decided by a 2/3 majority vote of those members of the editorial board
+who vote on the issue.
 
 Other issues, such as editorial policy, licensing policy, can be
 decided by a majority vote.

--- a/editorial_board.md
+++ b/editorial_board.md
@@ -1,5 +1,7 @@
 # Policies About the Editorial Boards
 
+These policies are currently a draft, and not yet in force.
+
 ## Policies on Decisions
 Issues regarding governance structure, editorial board membership, leadership, and financial
 model must be decided by a 2/3 majority vote of the voting members of the editorial

--- a/editorial_board.md
+++ b/editorial_board.md
@@ -1,0 +1,15 @@
+#Policies About the Editorial Boards
+
+## Policies on Decisions}
+Issues regarding governance structure, editorial board membership, leadership, and financial
+model must be decided by a 2/3 majority vote of the voting members of the editorial
+board.
+
+Other issues, such as editorial policy, licensing policy, can be
+decided by a majority vote.
+
+Votes will be are tallied based on the fraction of the editorial board
+responding within one week written notice via e-mail. In exceptional
+circumstances advance notice may be given of a rush decision, where
+the board may be given one week (or more) notice that their votes will
+be needed within a shorter window, such as a 12 hour window.

--- a/editorial_board.md
+++ b/editorial_board.md
@@ -1,6 +1,6 @@
-#Policies About the Editorial Boards
+# Policies About the Editorial Boards
 
-## Policies on Decisions}
+## Policies on Decisions
 Issues regarding governance structure, editorial board membership, leadership, and financial
 model must be decided by a 2/3 majority vote of the voting members of the editorial
 board.

--- a/index.md
+++ b/index.md
@@ -192,8 +192,8 @@ your work can reach and help the broadest audience possible, and
 suggest that when considering the appropriate license you [read this analysis](http://openaccess.ox.ac.uk/2013/06/13/cc-by-what-does-it-mean-for-scholarly-articles-3/).
 
 Other more restrictive licenses may be permissible as long as LiveCoMS
-has the permission to publish and excerpt from the document; this
-might be required if someone other than the authors has some rights to
+has the permission to publish and excerpt from the document; 
+another license might be needed if someone other than the authors has some rights to
 the material (for example, if it was previously published in some
 other journal). Generally, we only allow a more restrictive license in
 these cases, but are happy to discuss. Please ask the managing editors
@@ -222,16 +222,20 @@ Evaluating whether such changes constitute a significant revision will be part o
 
 ## Author Order
 Authors should, to the extent possible, determine the author order
-among themselves.  Each work must have a section describing the actual
-contributions of authors (and of those acknowledged) to provide
-clarity, and journal templates include such a section.  
-<!-- MRS: still need to add that section of the templates.  We should also likely provide more explicit instructions here as to how finely to divide the contributions. -->
+among themselves.  However, we acknowledge that institutions
+evaluating for merit, promotion, tenure or other cases may not read
+this level of detail, so traditional notions of author order (first
+author, corresponding author, etc.) may still be relevant and the
+authors will need to coordinate who should occupy these positions.
 
-However, we acknowledge that institutions evaluating for merit, promotion, tenure
-or other cases may not read this level of detail, so traditional
-notions of author order (first author, corresponding author, etc.) may
-still be relevant and the authors will need to coordinate who should
-occupy these positions.
+Each work must have a section describing the actual contributions of
+authors (and of those acknowledged) to provide clarity, and journal
+templates include such a section.  Please note, since this is an
+electronic-only journal, there is no length limit when you describe
+the authors' contributions, so we recommend describing what they
+actually did rather than simply categorizing them in a small number of
+roles as might be done in more conventional journals.
+<!-- MRS: still need to add that section of the templates somewhat -->  
 
 ## Abandoned Documents
 
@@ -242,11 +246,11 @@ do so, with appropriate modifications to the authors list. Authors
 would be given written notice (by e-mail and formal letter) if this
 were to happen and would have a period of six months to respond and/or
 designate a successor before LiveCoMS would do so for them. Typically,
-authors are _implicitly_ giving a right to do this via licensing under
+authors are *implicitly* giving a right to do this via licensing under
 [Creative Commons - Attribution](https://creativecommons.org/licenses/by/4.0/) or
 similar licenses which give others the right to create derivative
-works (potentially allowing others to ``resurrect'' a document which
-has been abandoned); however, we expect all authors to explicitly
+works (potentially allowing others to "resurrect" a document which
+has been abandoned); however, we expect all authors to *explicitly*
 consent to this policy to avoid any confusion. Ordinarily, we expect
 this policy will be relevant only in unusual or extreme cases where an
 author or authors dies or leaves the field; in most other cases
@@ -262,5 +266,3 @@ appropriate acknowledgment/recognition of the original authors) if
 they have abandoned their article as described above, and that
 LiveCoMS may accept revised versions of papers which have amended
 authorship in such circumstances.
-
-

--- a/index.md
+++ b/index.md
@@ -23,7 +23,10 @@ This article describes how [LiveCoMS](http://www.livecomsjournal.org) article pr
 - [Other Policies for Submitted Articles](#other-policies-for-submitted-articles)
   - [Funding Compliance](#funding-compliance)
   - [Licensing](#licensing)
-  - [Prior publication](#policy-on-prior-publication)
+  - [Prior publication](#prior-publication)
+  - [Author Order](#author-order)
+  - [Abandoned Documents](#abandoned-documents)
+
 
 # The Process of Submitting an Article to LiveCoMS
 
@@ -172,11 +175,41 @@ Authors should note whether any funding could be perceived as a conflict of inte
 
 ## Licensing 
 
-LiveCoMS does not require any copyright transfer to the journal.  
-Instead, LiveCoMS requires articles use a license which allows LiveCoMS to distribute the articles freely consistent with Open Access requirements. 
-We recommend that all submissions to LiveCoMS be released by the author under a Creative Commons By Attribution license version 4.0; however, other licenses may be acceptable with justification.
+LiveCoMS does not request or allow any copyright transfer.
 
-## Policy on Prior Publication
+However, in order to submit to LiveCoMS, authors must provide, at
+minimum, a license for LiveCoMS to publish the article and distribute
+it free of charge. We recommend that the authors release the article
+under an open source license such as [Creative Commons
+  Attribution](https://creativecommons.org/licenses/by/4.0/}{Creative Commons
+  Attribution) (also known as CC-BY) releasing the document for anyone to copy and
+redistribute the material in any medium or format, and remix,
+transform, and build upon the material for any purpose, even
+commercially.  Making it available to all of course makes it possible
+for LiveCoMS to publish it, and for the community to edit and
+contribute.  We highly recommend the CC-BY license in order to ensure
+your work can reach and help the broadest audience possible, and
+suggest that when considering the appropriate license you [read this analysis](http://openaccess.ox.ac.uk/2013/06/13/cc-by-what-does-it-mean-for-scholarly-articles-3/)
+
+Other more restrictive licenses may be permissible as long as LiveCoMS
+has the permission to publish and excerpt from the document; this
+might be required if someone other than the authors has some rights to
+the material (for example, if it was previously published in some
+other journal). Generally, we only allow a more restrictive license in
+these cases, but are happy to discuss. Please ask the managing editors
+if you require some other licensing regime.
+
+For employees of the U.S. Government, their work products are under
+public domain, and thus CC-BY is not appropriate. We recommend the
+license language: "As a work of the United States Government, this
+package is in the public domain within the United
+States. Additionally, \\\[Agency Name\\\] waives copyright and related
+rights in the work worldwide through the CC0 1.0 Universal Public
+Domain Dedication (which can be found at
+https://creativecommons.org/publicdomain/zero/1.0/)."
+[See the analysis of this language here](https://theunitedstates.io/licensing/)
+
+## Prior Publication
 
 Documents should not have been submitted in the current form to another journal, or be simultaneously under consideration for publication another journal. 
 Preprints do not count as prior publication. 
@@ -187,4 +220,50 @@ Some journals, for example, *Annual Reviews* lets the authors retain the right t
 If an article is an adaptation of a previously published article, it must be noted in the cover letter, and major changes noted. 
 Evaluating whether such changes constitute a significant revision will be part of the review process.
 
+##Author Order
+Authors should, to the extent possible, determine the author order
+among themselves.  Each work must have a section describing the actual
+contributions of authors (and of those acknowledged) to provide
+clarity, and journal templates include such a section.  
+<!-- MRS: still need to add that section of the templates.  We should also likely provide more explicit instructions here as to how finely to divide the contributions. -->
 
+However, we acknowledge that institutions evaluating for merit, promotion, tenure
+or other cases may not read this level of detail, so traditional
+notions of author order (first author, corresponding author, etc.) may
+still be relevant and the authors will need to coordinate who should
+occupy these positions.
+
+##Abandoned Documents
+
+By the submission of their paper, document, or materials, all the
+authors consent that if they no longer are willing or able to maintain
+their work, LiveCoMS may assign another individual or individuals to
+do so, with appropriate modifications to the authors list. Authors
+would be given written notice (by e-mail and formal letter) if this
+were to happen and would have a period of six months to respond and/or
+designate a successor before LiveCoMS would do so for them. Typically,
+authors are _implicitly_ giving a right to do this via licensing under
+[Creative Commons - Attribution](https://creativecommons.org/licenses/by/4.0/) or
+similar licenses which give others the right to create derivative
+works (potentially allowing others to ``resurrect'' a document which
+has been abandoned); however, we expect all authors to explicitly
+consent to this policy to avoid any confusion. Ordinarily, we expect
+this policy will be relevant only in unusual or extreme cases where an
+author or authors dies or leaves the field; in most other cases
+authors will presumably be available to designate their own successors
+or succession plan if a work is valuable to the field and will
+continue to need maintenance and the original author(s) are no longer
+willing or able to do so. However, we want to plan for the possibility
+of unusual events, hence our need for this policy.
+
+Thus, for these reasons, authors submitting to LiveCoMS are agreeing
+that others may take over authorship of their article (with
+appropriate acknowledgment/recognition of the original authors) if
+they have abandoned their article as described above, and that
+LiveCoMS may accept revised versions of papers which have amended
+authorship in such circumstances.
+
+
+ LocalWords:  LiveCoMS livecoms Presubmission presubmission md GitHub PDF ArXiv
+ LocalWords:  BioRxiv ChemRxiv engrXiv website postdocs DOI versioning curated
+ LocalWords:  updatable Markdown CC remix

--- a/index.md
+++ b/index.md
@@ -234,7 +234,7 @@ templates include such a section.  Please note, since this is an
 electronic-only journal, there is no length limit when you describe
 the authors' contributions, so we recommend describing what they
 actually did rather than simply categorizing them in a small number of
-roles as might be done in more conventional journals.
+predefined roles as might be done in more conventional journals.
 <!-- MRS: still need to add that section of the templates somewhat -->  
 
 ## Abandoned Documents

--- a/index.md
+++ b/index.md
@@ -189,7 +189,7 @@ commercially.  Making it available to all of course makes it possible
 for LiveCoMS to publish it, and for the community to edit and
 contribute.  We highly recommend the CC-BY license in order to ensure
 your work can reach and help the broadest audience possible, and
-suggest that when considering the appropriate license you [read this analysis](http://openaccess.ox.ac.uk/2013/06/13/cc-by-what-does-it-mean-for-scholarly-articles-3/)
+suggest that when considering the appropriate license you [read this analysis](http://openaccess.ox.ac.uk/2013/06/13/cc-by-what-does-it-mean-for-scholarly-articles-3/).
 
 Other more restrictive licenses may be permissible as long as LiveCoMS
 has the permission to publish and excerpt from the document; this
@@ -203,11 +203,11 @@ For employees of the U.S. Government, their work products are under
 public domain, and thus CC-BY is not appropriate. We recommend the
 license language: "As a work of the United States Government, this
 package is in the public domain within the United
-States. Additionally, \\\[Agency Name\\\] waives copyright and related
+States. Additionally, \[Agency Name\] waives copyright and related
 rights in the work worldwide through the CC0 1.0 Universal Public
 Domain Dedication (which can be found at
 https://creativecommons.org/publicdomain/zero/1.0/)."
-[See the analysis of this language here](https://theunitedstates.io/licensing/)
+[See the analysis of this language here](https://theunitedstates.io/licensing/).
 
 ## Prior Publication
 
@@ -220,7 +220,7 @@ Some journals, for example, *Annual Reviews* lets the authors retain the right t
 If an article is an adaptation of a previously published article, it must be noted in the cover letter, and major changes noted. 
 Evaluating whether such changes constitute a significant revision will be part of the review process.
 
-##Author Order
+## Author Order
 Authors should, to the extent possible, determine the author order
 among themselves.  Each work must have a section describing the actual
 contributions of authors (and of those acknowledged) to provide
@@ -233,7 +233,7 @@ notions of author order (first author, corresponding author, etc.) may
 still be relevant and the authors will need to coordinate who should
 occupy these positions.
 
-##Abandoned Documents
+## Abandoned Documents
 
 By the submission of their paper, document, or materials, all the
 authors consent that if they no longer are willing or able to maintain
@@ -264,6 +264,3 @@ LiveCoMS may accept revised versions of papers which have amended
 authorship in such circumstances.
 
 
- LocalWords:  LiveCoMS livecoms Presubmission presubmission md GitHub PDF ArXiv
- LocalWords:  BioRxiv ChemRxiv engrXiv website postdocs DOI versioning curated
- LocalWords:  updatable Markdown CC remix


### PR DESCRIPTION
Moved the information in editorial_policies.tex to the webpage.  Most article policies were moved the index.md web page, to centralize where the "for the authors" information would be.

The editorial_board.md file is not currently linked from anywhere, since it's just a draft and not yet in force.

When this PR is accepted, the editorial_policies.tex and editorial_policies.pdf files will be removed from the journal_information repository.