### PR TITLE
Updates to perpetual reviews; clean up editorial board policies

### DIFF
--- a/_policies/03_perpetual_reviews.md
+++ b/_policies/03_perpetual_reviews.md
@@ -19,8 +19,15 @@ updated regularly on GitHub.
 * Do the authors properly include information from the recent literature, including last 6 to 12 months?
 * Is this a good summary of its area which will be valuable to the field?
 * Do the authors include data and viewpoints that are contradictory to their own, if these exist?
-* (If a revision) Have the authors removed data that is out of date, and qualified information that has been disproven or contradicted?
+* (If a revision) Have the authors removed outdated material and qualified information that has been disproven or contradicted? Does the revision add the appropriate and relevant new material or is it becoming outdated?
 
-## Revision schedule for best practices guides
-Authors are requested to update reviews at least once every 36 months, and will be encouraged to ensure continuity of authorship (e.g. if one author retires or loses interest) so the review can be maintained, or else the review will be “made emeritus” and indicated as out-of-date on the site.  We recommend updating at least every 24 months.  However, authors decide when it is time to re-version based on feedback they receive. 
+## Revision schedule for perpetual reviews
+Authors should update reviews at least once every 36 months, and will be encouraged to ensure continuity of authorship (e.g. if one author retires or loses interest) so the review can be maintained, or else the review will be “made emeritus” and indicated as out-of-date on the site. 
+We recommend updating at least every 24 months. 
+However, authors decide when it is time to re-version based on feedback they receive, with help from the Lead Editor for Perpetual Reviews as needed. 
 
+We recommend that authors take a two-prong approach to updates:
+- Regularly make updates on their GitHub repository as they become aware of new material, developments, etc., issuing minor "releases" of their work when these changes warrant
+- Submit a new version of their work for peer review and additional publication when either (a) a larger change to the work is needed, or (b) enough incremental updates have accrued that the work has become significantly different. 
+
+Necessarily this will involve some degree of subjectivity; if it is unclear, the authors should consult with the relevant editor.

--- a/_policies/08_editorial_board.md
+++ b/_policies/08_editorial_board.md
@@ -7,6 +7,8 @@ excerpt: A draft of the policies of the editorial board.
 permalink: /editorial_board/
 ---
 
+These policies are currently a draft, and not yet in force.
+
 ## Policies on Decisions 
 Issues regarding governance structure, editorial board membership, leadership, and financial model must be decided by a 2/3 majority vote of those members of the editorial board
 who vote on the issue.

--- a/_policies/08_editorial_board.md
+++ b/_policies/08_editorial_board.md
@@ -7,11 +7,8 @@ excerpt: A draft of the policies of the editorial board.
 permalink: /editorial_board/
 ---
 
-These policies are currently a draft, and not yet in force.
-
-## Policies on Decisions Issues regarding governance structure,
-editorial board membership, leadership, and financial model must be
-decided by a 2/3 majority vote of those members of the editorial board
+## Policies on Decisions 
+Issues regarding governance structure, editorial board membership, leadership, and financial model must be decided by a 2/3 majority vote of those members of the editorial board
 who vote on the issue.
 
 Other issues, such as editorial policy, licensing policy, can be


### PR DESCRIPTION
Updates the info on perpetual reviews to add a few more details and clean up some formatting. Also cleans up the document on editorial board policies, including removing the "these policies are not yet in force" phrasing since we (a) don't have that on any other pages, and (b) need to remove it at some point.