### PR TITLE
Fix broken link on landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ header:
   overlay_image: /assets/images/livecoms-splash.jpg
 excerpt: "Submission, review, and editorial policies"
 intro: 
-  - excerpt: 'This website details the submission, review, and editorial policies of LiveCoMS, the Living Journal of Computational Molecular Science. Please visit [www.livecomsjournal.org](www.livecomsjournal.org) for more information.'
+  - excerpt: 'This website details the submission, review, and editorial policies of LiveCoMS, the Living Journal of Computational Molecular Science. Please visit [www.livecomsjournal.org](https://www.livecomsjournal.org) for more information.'
 ---
 
 {% include feature_row id="intro" type="center" %}


### PR DESCRIPTION
Link to the liveCOMS journal on the landing page was broken.

Included `https://` seems to be fix. Apparently without that,
the link is treated as a relative instead of an absolute link.

Was not able to test on my machine however, but that seems to be the
case for the other working links to LiveCOMS throughout the site.