### PR TITLE
Changes in website navigation

### DIFF
--- a/_about_livecoms/01_paper_code.md
+++ b/_about_livecoms/01_paper_code.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: paper_code.md
+  nav: about_paper_code.md
 title: Paper writing as code development
 excerpt: Why a code development model can be used to improve paper writing as well.
-permalink: /paper_code/
+permalink: /about/paper_code
 ---
 
 Modern code development can be highly collaborative, with authors taking advantage of feedback from peers or experts in their area as their code is reviewed.

--- a/_about_livecoms/index.md
+++ b/_about_livecoms/index.md
@@ -1,0 +1,20 @@
+---
+title: "Living Journal of Computational Molecular Science"
+layout: archive
+permalink: /about/
+header:
+  overlay_color: "#000"
+  overlay_filter: "0.5"
+  overlay_image: /assets/images/livecoms-splash.jpg
+excerpt: "About LiveCoMS"
+---
+
+{% for collection in site.collections %}
+  {% if collection.label == "about_livecoms" %}
+    {% for post in collection.docs %}
+	  {% if post.layout != "archive" %}
+        {% include archive-single.html %}
+	  {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: "policies.md"
-title: The Process of Submitting an Article to LiveCoMS
+  nav: authors_policies.md
+title: General Author Instructions
 excerpt: This article describes how LiveCoMS article preparation and submission work, as well as giving details of the review process, revisions, authorship, and other aspects.
-permalink: /policies/
+permalink: /authors/policies/
 ---
 
 This article describes how [LiveCoMS](http://www.livecomsjournal.org) article preparation and submission work, as well as giving details of the review process, revisions, authorship, and other aspects.

--- a/_author_instructions/02_best_practices.md
+++ b/_author_instructions/02_best_practices.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: best_practices.md
+  nav: authors_best_practices.md
 title: Best Practices Guides
 excerpt: "What are best practices guides?"
-permalink: /best_practices/
+permalink: /authors/best_practices/
 ---
 
 ## What is a best practices guide?

--- a/_author_instructions/03_perpetual_reviews.md
+++ b/_author_instructions/03_perpetual_reviews.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: perpetual_reviews.md
+  nav: authors_perpetual_reviews.md
 title: Perpetual Reviews
 excerpt: What are perpetual reviews?
-permalink: /perpetual_reviews/
+permalink: /authors/perpetual_reviews/
 ---
 
 ## What is a perpetual review?

--- a/_author_instructions/04_compare_simulations.md
+++ b/_author_instructions/04_compare_simulations.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: compare_simulations.md
+  nav: authors_compare_simulations.md
 title: Comparisons of Molecular Simulation Packages
 excerpt: What is a publishable comparison for molecular simulation packages?
-permalink: /compare_simulations/
+permalink: /authors/compare_simulations/
 ---
 
 ## What is a publishable comparison for molecular simulation packages?

--- a/_author_instructions/05_tutorials.md
+++ b/_author_instructions/05_tutorials.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: tutorials.md
+  nav: authors_tutorials.md
 title: Tutorials
 excerpt: What is a publishable tutorial?
-permalink: /tutorials/
+permalink: /authors/tutorials/
 ---
 
 ## What is a publishable tutorial?

--- a/_author_instructions/06_lessons_learned.md
+++ b/_author_instructions/06_lessons_learned.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: lessons_learned.md
+  nav: authors_lessons_learned.md
 title: "Lessons Learned"
 excerpt: What is a "lesson learned" (i.e. negative results) document?
-permalink: /lessons_learned/
+permalink: /authors/lessons_learned/
 ---
 
 ## What is a "lesson learned" (i.e. negative results) document?

--- a/_author_instructions/index.md
+++ b/_author_instructions/index.md
@@ -1,0 +1,20 @@
+---
+title: "Living Journal of Computational Molecular Science"
+layout: archive
+permalink: /authors/
+header:
+  overlay_color: "#000"
+  overlay_filter: "0.5"
+  overlay_image: /assets/images/livecoms-splash.jpg
+excerpt: "Author instructions"
+---
+
+{% for collection in site.collections %}
+  {% if collection.label == "author_instructions" %}
+    {% for post in collection.docs %}
+	  {% if post.layout != "archive" %}
+        {% include archive-single.html %}
+	  {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}

--- a/_config.yml
+++ b/_config.yml
@@ -237,9 +237,12 @@ compress_html:
 
 # Collections
 collections:
-  policies:
+  author_instructions:
     output: true
-    permalink: /:path/
+  editorial_policies:
+    output: true
+  about_livecoms:
+    output: true
 
 
 # Defaults

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,141 +1,138 @@
 main:
-  - title: Policies
+  - title: Author Instructions
+    url: /authors/
+  - title: Editorial Policies
     url: /policies/
-  - title: Best Practices
-    url: /best_practices/
-  - title: Reviews
-    url: /perpetual_reviews/
-  - title: Simulation Comparisons
-    url: /compare_simulations/
-  - title: Tutorials
-    url: /tutorials/
-  - title: Lessons Learned
-    url: /lessons_learned/
-  - title: Paper Writing
-    url: /paper_code/
-  - title: Editorial Board
-    url: /editorial_board/
+  - title: About LiveCoMS
+    url: /about/
 
 policies.md:
-  - title: The Process of Submitting an Article to LiveCoMS
-    url: /policies/index.html#
+  - title: General Author Instructions
+    url: /authors/policies/index.html#
     children:
     - title: Introduction
-      url: /policies/index.html#introduction
+      url: /authors/policies/index.html#introduction
     - title: General Article Guidelines
-      url: /policies/index.html#general-article-guidelines
+      url: /authors/policies/index.html#general-article-guidelines
     - title: Types of Articles
-      url: /policies/index.html#types-of-articles
+      url: /authors/policies/index.html#types-of-articles
   - title: Before Submission
-    url: /policies/index.html#before-submission
+    url: /authors/policies/index.html#before-submission
     children:
     - title: Presubmission Letter
-      url: /policies/index.html#presubmission-letter
+      url: /authors/policies/index.html#presubmission-letter
     - title: Preparation of Your Article For Submission
-      url: /policies/index.html#preparation-of-your-article-for-submission
+      url: /authors/policies/index.html#preparation-of-your-article-for-submission
+      children:
+      - title: Writing style and editing
+        url: /authors/policies/index.html#writing-style-and-editing
+      - title: Article layout
+        url: /authors/policies/index.html#article-layout
+      - title: Preprints
+        url: /authors/policies/index.html#preprints
   - title: Submission and the Review Process
-    url: /policies/index.html#submission-and-the-review-process
+    url: /authors/policies/index.html#submission-and-the-review-process
     children:
     - title: Article submission
-      url: /policies/index.html#article-submission
+      url: /authors/policies/index.html#article-submission
     - title: The review process
-      url: /policies/index.html#the-review-process
+      url: /authors/policies/index.html#the-review-process
     - title: Review criteria
-      url: /policies/index.html#review-criteria
+      url: /authors/policies/index.html#review-criteria
     - title: The Revision Process
-      url: /policies/index.html#the-revision-process
+      url: /authors/policies/index.html#the-revision-process
   - title: Updating LiveCoMS Articles
-    url: /policies/index.html#updating-livecoms-articles
+    url: /authors/policies/index.html#updating-livecoms-articles
     children:
     - title: Engaging the Community in Improving Articles
-      url: /policies/index.html#engaging-the-community-in-improving-articles
+      url: /authors/policies/index.html#engaging-the-community-in-improving-articles
     - title: Paper Writing as Code Development
-      url: /policies/index.html#paper-writing-as-code-development
+      url: /authors/policies/index.html#paper-writing-as-code-development
   - title: Authorship and Changes to Authorship
-    url: /policies/index.html#authorship-and-changes-to-authorship
+    url: /authors/policies/index.html#authorship-and-changes-to-authorship
   - title: Other Policies for Submitted Articles
-    url: /policies/index.html#other-policies-for-submitted-articles
+    url: /authors/policies/index.html#other-policies-for-submitted-articles
     children:
     - title: Funding Compliance
-      url: /policies/index.html#funding-compliance
+      url: /authors/policies/index.html#funding-compliance
     - title: Licensing
-      url: /policies/index.html#licensing
+      url: /authors/policies/index.html#licensing
     - title: Prior Publication
-      url: /policies/index.html#prior-publication
+      url: /authors/policies/index.html#prior-publication
     - title: Author Order
-      url: /policies/index.html#author-order
+      url: /authors/policies/index.html#author-order
     - title: Abandoned Documents
-      url: /policies/index.html#abandoned-documents
+      url: /authors/policies/index.html#abandoned-documents
 
 best_practices.md:
   - title: Best Practices Guides
-    url: /best_practices/index.html#
+    url: /authors/best_practices/index.html#
     children:
     - title: What is a best practices guide?
-      url: /best_practices/index.html#what-is-a-best-practices-guide
+      url: /authors/best_practices/index.html#what-is-a-best-practices-guide
     - title: Additional factors considered in review of best practices guides
-      url: /best_practices/index.html#additional-factors-considered-in-review-of-best-practices-guides
+      url: /authors/best_practices/index.html#additional-factors-considered-in-review-of-best-practices-guides
     - title: Revision schedule for best practices guides
-      url: /best_practices/index.html#revision-schedule-for-best-practices-guides
+      url: /authors/best_practices/index.html#revision-schedule-for-best-practices-guides
 
 perpetual_reviews.md:
   - title: Perpetual Reviews
-    url: /perpetual_reviews/index.html#
+    url: /authors/perpetual_reviews/index.html#
     children:
     - title: What is a perpetual review?
-      url: /perpetual_reviews/index.html#what-is-a-perpetual-review
+      url: /authors/perpetual_reviews/index.html#what-is-a-perpetual-review
     - title: Additional review criteria for perpetual reviews
-      url: /perpetual_reviews/index.html#additional-review-criteria-for-perpetual-reviews
+      url: /authors/perpetual_reviews/index.html#additional-review-criteria-for-perpetual-reviews
     - title: Revision schedule for best practices guides
-      url: /perpetual_reviews/index.html#revision-schedule-for-best-practices-guides
+      url: /authors/perpetual_reviews/index.html#revision-schedule-for-best-practices-guides
 
 compare_simulations.md:
   - title: Comparisons of Molecular Simulation Packages
-    url: /compare_simulations/index.html#
+    url: /authors/compare_simulations/index.html#
     children:
     - title: What is a publishable comparison for molecular simulation packages?
-      url: /compare_simulations/index.html#what-is-a-publishable-comparison-for-molecular-simulation-packages
+      url: /authors/compare_simulations/index.html#what-is-a-publishable-comparison-for-molecular-simulation-packages
     - title: Additional factors considered in review of comparisons of molecular simulation programs
-      url: /compare_simulations/index.html#additional-factors-considered-in-review-of-comparisons-of-molecular-simulation-programs
+      url: /authors/compare_simulations/index.html#additional-factors-considered-in-review-of-comparisons-of-molecular-simulation-programs
     - title: Revision schedule for comparisons of molecular simulation programs
-      url: /compare_simulations/index.html#revision-schedule-for-comparisons-of-molecular-simulation-programs
+      url: /authors/compare_simulations/index.html#revision-schedule-for-comparisons-of-molecular-simulation-programs
 
 tutorials.md:
   - title: Tutorials
-    url: /tutorials/index.html#
+    url: /authors/tutorials/index.html#
     children:
     - title: What is a publishable tutorial?
-      url: /tutorials/index.html#what-is-a-publishable-tutorial
+      url: /authors/tutorials/index.html#what-is-a-publishable-tutorial
     - title: Additional factors considered in review of tutorials
-      url: /tutorials/index.html#additional-factors-considered-in-review-of-tutorials
+      url: /authors/tutorials/index.html#additional-factors-considered-in-review-of-tutorials
     - title: Revision schedule for tutorials
-      url: /tutorials/index.html#revision-schedule-for-tutorials
+      url: /authors/tutorials/index.html#revision-schedule-for-tutorials
 
 lessons_learned.md:
-  - title: "Lessons Learned"
-    url: /lessons_learned/index.html#
+  - title: Lessons Learned
+    url: /authors/lessons_learned/index.html#
     children:
     - title: What is a "lesson learned" (i.e. negative results) document?
-      url: /lessons_learned/index.html#what-is-a-lesson-learned-ie-negative-results-document
+      url: /authors/lessons_learned/index.html#what-is-a-lesson-learned-ie-negative-results-document
     - title: Additional factors considered in review of "lessons learned" documents
-      url: /lessons_learned/index.html#additional-factors-considered-in-review-of-lessons-learned-documents
+      url: /authors/lessons_learned/index.html#additional-factors-considered-in-review-of-lessons-learned-documents
     - title: Revision schedule for "lessons learned" documents
-      url: /lessons_learned/index.html#revision-schedule-for-lessons-learned-documents
-
-paper_code.md:
-  - title: Paper writing as code development
-    url: /paper_code/index.html#
-    children:
-    - title: Incentives
-      url: /paper_code/index.html#incentives
-    - title: Tools for paper writing/code development
-      url: /paper_code/index.html#tools-for-paper-writingcode-development
-    - title: How it works in practice
-      url: /paper_code/index.html#how-it-works-in-practice
+      url: /authors/lessons_learned/index.html#revision-schedule-for-lessons-learned-documents
 
 editorial_board.md:
   - title: Policies About the Editorial Board
-    url: /editorial_board/index.html#
+    url: /policies/editorial_boardindex.html#
     children:
     - title: Policies on Decisions Issues regarding governance structure,
-      url: /editorial_board/index.html#policies-on-decisions-issues-regarding-governance-structure
+      url: /policies/editorial_boardindex.html#policies-on-decisions-issues-regarding-governance-structure
+
+paper_code.md:
+  - title: Paper writing as code development
+    url: /about/paper_codeindex.html#
+    children:
+    - title: Incentives
+      url: /about/paper_codeindex.html#incentives
+    - title: Tools for paper writing/code development
+      url: /about/paper_codeindex.html#tools-for-paper-writingcode-development
+    - title: How it works in practice
+      url: /about/paper_codeindex.html#how-it-works-in-practice

--- a/_editorial_policies/01_editorial_board.md
+++ b/_editorial_policies/01_editorial_board.md
@@ -1,10 +1,10 @@
 ---
 layout: single
 sidebar:
-  nav: editorial_board.md
+  nav: policies_editorial_board.md
 title: Policies About the Editorial Board
 excerpt: A draft of the policies of the editorial board.
-permalink: /editorial_board/
+permalink: /policies/editorial_board
 ---
 
 These policies are currently a draft, and not yet in force.

--- a/_editorial_policies/index.md
+++ b/_editorial_policies/index.md
@@ -1,0 +1,20 @@
+---
+title: "Living Journal of Computational Molecular Science"
+layout: archive
+permalink: /policies/
+header:
+  overlay_color: "#000"
+  overlay_filter: "0.5"
+  overlay_image: /assets/images/livecoms-splash.jpg
+excerpt: "Editorial policies"
+---
+
+{% for collection in site.collections %}
+  {% if collection.label == "editorial_policies" %}
+    {% for post in collection.docs %}
+	  {% if post.layout != "archive" %}
+        {% include archive-single.html %}
+	  {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}

--- a/index.md
+++ b/index.md
@@ -6,18 +6,27 @@ header:
   overlay_color: "#000"
   overlay_filter: "0.5"
   overlay_image: /assets/images/livecoms-splash.jpg
-excerpt: "Submission, review, and editorial policies"
+excerpt: "Author instructions and journal information"
 intro: 
-  - excerpt: 'This website details the submission, review, and editorial policies of LiveCoMS, the Living Journal of Computational Molecular Science. Please visit [www.livecomsjournal.org](http://www.livecomsjournal.org) for more information.'
+  - excerpt: 'This website provides author instructions and policy and journal information for LiveCoMS, the Living Journal of Computational Molecular Science. Please visit [www.livecomsjournal.org](http://www.livecomsjournal.org) for more information.'
+feature_row:
+  - title: Author Instructions
+    url: /authors/
+    # image_path: assets/images/authors.jpg
+    # alt: "Author Instructions"
+    excerpt: "General instructions for authors as well as details on the different article types featured in LiveCoMS"
+  - title: Editorial Policies
+    url: /policies/
+    # image_path: assets/images/policies.jpg
+    # alt: "Editorial Policies"
+    excerpt: "A draft of the policies of the editorial board"
+  - title: About LiveCoMS
+    url: /about/
+    # image_path: assets/images/about.jpg
+    # alt: "About LiveCoMS"
+    excerpt: "Learn more about the model of LiveCoMS"
 ---
 
 {% include feature_row id="intro" type="center" %}
 
-{% for collection in site.collections %}
-  {% if collection.label == "policies" %}
-    {% for post in collection.docs %}
-      {% include archive-single.html %}
-    {% endfor %}
-  {% endif %}
-{% endfor %}
-
+{% include feature_row %}


### PR DESCRIPTION
Implementing some of the points discussed in issue #45.

* The main navigation is changed to have 3 categories:
  - Author Instructions
  - Editorial Policies
  - About LiveCoMS
* The landing page is changed from listing all website entries to having a
  link to the 3 categories detailed above. These links could have an image
  each, as suggested by @davidmobley - the code is commented out in the
  index.md file until we have decided for images.
* To facilitate these changes, all files were moved from being located in
  the _policies/ folder to being in the _author_instructions/,
  _editorial_policies/ and _about_livecoms/ folders. These folders are
  interpreted as categories by jekyll.
* 3 new index files were create for the 3 new categories. The main
  navigation and the three links on the main page link to these new index
  files. The index files automatically list all files of the category
  (i.e. being in the same folder).
* The generate_navigation.py script was updated to reflect these changes.
  Note: Requires the yaml package to read the jekyll front matter of the
  files.

HOW TO DO CHANGES TO THE WEBSITE:
* Edit any *.md file in the category folders (_author_instructions/,
  _editorial_policies/ and _about_livecoms/), except index.md:
  Edit as needed. If you change or add any (sub)title, or change their
  order, run the navigation generation script:
  `python3 generate_toc.py > _data/navigation.yml`
* Add any *.md file in the category folders (_author_instructions/,
  _editorial_policies/ and _about_livecoms/):
  Simply add the file, and run the script:
  `python3 generate_toc.py > _data/navigation.yml`
  The new file should automatically be indexed by the index file,
  the order follows the alphabetical order of the file names, so you might
  want to change the filename if you don't like the order. The new file
  is also recognized by the script, and an entry for the sidebar is
  written to the navigation file. Be careful to chose values for permalink
  and sidebar nav in the frontmatter which are not used by any other file,
  or leave those keywords away (in which case the script is going to chose
  these values for you).
* Edit index.md files:
  Any Markdown text can be added before or after (or probably betweeen) the
  jekyll commands. I'd suggest to install a jekyll environment and try
  changes before comitting them.