### PR TITLE
Changes to featurerow

### DIFF
--- a/_includes/feature_row
+++ b/_includes/feature_row
@@ -30,7 +30,13 @@
 
         <div class="archive__item-body">
           {% if f.title %}
-            <h2 class="archive__item-title">{{ f.title }}</h2>
+            <h2 class="archive__item-title">
+            {% if f.url %}
+              <a href="{{ f_url }}" style="color: inherit">{{ f.title }}</a>
+            {% else %}
+              {{ f.title }}
+            {% endif %}
+            </h2>
           {% endif %}
 
           {% if f.excerpt %}

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -75,10 +75,6 @@
   .archive__item-teaser {
     box-shadow: 0 0 10px rgba(#000, 0.25);
   }
-
-  .archive__item-title {
-    text-decoration: underline;
-  }
 }
 
 


### PR DESCRIPTION
Makes title of elements of feature row clickable (if url is present)
or removes the mouse-over underlining (if no url, to avoid confusion
with a clickable link). Fixes issue #73.