### PR TITLE
Don't truncate manually-specified excerpts so drastically

### DIFF
--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -3,20 +3,20 @@ layout: single
 sidebar:
   nav: authors_policies.md
 title: General Author Instructions
-excerpt: This article describes how LiveCoMS article preparation and submission work, as well as giving details of the review process, revisions, authorship, and other aspects.
+excerpt: Overview of article preparation, submission, and review.
 permalink: /authors/policies/
 ---
 
-This article describes how [LiveCoMS](http://www.livecomsjournal.org) article preparation and submission work, as well as giving details of the review process, revisions, authorship, and other aspects.
+This article describes how [LiveCoMS](http://www.livecomsjournal.org) article preparation and submission work, and provides details covering the review process, revisions, authorship, and other aspects.
 
 ## Introduction
 
-Submitting an article to LiveCoMS is substantially different from submitting an article to most journals. 
+Submitting an article to LiveCoMS is substantially different from submitting an article to most journals.
 In this article, we lay out the process by which authors create an article, submit it to LiveCoMS, and update it over time to create a living document.  
 
 ## General Article Guidelines
 
-There are no explicit length limits on any manuscript. 
+There are no explicit length limits on any manuscript.
 Articles do not need to contain original research, but may contain it.
 Currently, articles in LiveCoMS must be submitted as one of the article types noted below.
 
@@ -41,7 +41,7 @@ Click each type of article for more information for submitting an article of tha
 Authors should first send a presubmission letter to the [lead editor in the relevant area](http://www.livecomsjournal.org/editorial-board).
 The letter should be no more than one page, and should:
 * Outline the scope of the proposed contribution.
-* Explain how the proposed manuscript is different from existing published work. 
+* Explain how the proposed manuscript is different from existing published work.
 * Note whether the manuscript is adapted from a previous article (and identify the article if so).
 * Explain the expertise that the proposed authors have on the subject.
 * Describe the license that the authors will use that will enable the article to be released freely to the public.
@@ -53,12 +53,12 @@ Articles should be submitted within six months of a notification of encouragemen
 
 The authors should prepare the document using
 [LaTeX](https://www.latex-project.org/) in a public repository owned
-by one of the authors (or their organization/group) on [GitHub](http://wwww.github.com). 
+by one of the authors (or their organization/group) on [GitHub](http://wwww.github.com).
 LiveCoMS [provides template LaTeX files to start from](https://github.com/livecomsjournal/article_templates), and instructions for how to structure the documents.
 We require that articles submitted to LiveCoMS use the provided templates so that the journal has a consistent visual presentation.
-Additionally, articles should include clear links to, and mention of, the relevant GitHub repository and encourage community participation/feedback via GitHub. 
+Additionally, articles should include clear links to, and mention of, the relevant GitHub repository and encourage community participation/feedback via GitHub.
 
-For an example of an article hosted on GitHub in this style (though not a LiveCoMS article), see [the following perpetual review](https://github.com/MobleyLab/benchmarksets). 
+For an example of an article hosted on GitHub in this style (though not a LiveCoMS article), see [the following perpetual review](https://github.com/MobleyLab/benchmarksets).
 
 ### Writing style and editing
 
@@ -72,7 +72,7 @@ In general we recommend authors follow the [ACS Style Guide](http://pubs.acs.org
 We also find Plaxco's [The Art of Writing Science](http://dx.doi.org/10.1002/pro.514) to be a particularly helpful concise summary of our desired style.
 
 It is particularly important to note that **LiveCoMS does not edit articles in detail, so it is important to arrange for your own editing**.
-You may receive some comments from your editor and/or the peer reviewers that point out typos or other issues, but you **should not rely** on this for your editing process. 
+You may receive some comments from your editor and/or the peer reviewers that point out typos or other issues, but you **should not rely** on this for your editing process.
 In order to keep costs to authors at a minimum, we do not employ copy editors, so be sure to arrange for your own editing.
 
 Articles can have any length; however, you should be as concise as possible.
@@ -103,11 +103,11 @@ However, you are also free to post your article to standard preprint servers, su
 * [Faculty of 1000 Research](https://f1000research.com)
 * Any of the [Open Science Framework preprint servers](https://osf.io/preprints/) (engrXiv, etc.)
 
-Posting to a preprint server can be done at any time prior to submission. 
+Posting to a preprint server can be done at any time prior to submission.
 
 # Submission and the Review Process
 
-## Article submission 
+## Article submission
 
 When ready for submission, the author uploads the final
 article PDF (created using the [LiveCoMS
@@ -128,35 +128,35 @@ If there are major issues at this stage, your article may be returned for revisi
 Reviews will generally be anonymous, though reviewers will be allowed to make themselves known if they desire.
 Reviewers can also participate directly in revisions through the GitHub website, whether or not they remain anonymous.
 For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly.
-This open revision approach may be particularly suitable for articles which will become community resources. 
+This open revision approach may be particularly suitable for articles which will become community resources.
 
-## Review criteria 
+## Review criteria
 
-A key purpose of the articles is that they should be useful to a range of researchers, but especially beginning researchers. 
+A key purpose of the articles is that they should be useful to a range of researchers, but especially beginning researchers.
 Thus, all submitted manuscripts will be reviewed by a member of the student review board, which consists of graduate students and postdocs invited by the editorial board.
 
 Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue
 tracker.  A history of revisions in response to community concerns will impact the review process favorably.
 
 Reviewers will also be asked to assess whether articles are well edited and clearly written.
-Authors whose article uses inconsistent style or poor grammar, or is poorly edited, may be asked to revise and address these issues. 
+Authors whose article uses inconsistent style or poor grammar, or is poorly edited, may be asked to revise and address these issues.
 
 Reviews will also consider the additional factors according to manuscript category: [please see the individual category links](#types-of-articles) for more information on these review criteria.
 
 
 ## The Revision Process
 
-If manuscript revision is requested, authors will typically be asked to re-submit within 30 days for minor revisions and 60 days for major revisions. 
+If manuscript revision is requested, authors will typically be asked to re-submit within 30 days for minor revisions and 60 days for major revisions.
 After this time, a revised manuscript may be handled as a new submission.
 
 # Updating LiveCoMS Articles
 
-A unique aspect of LiveCoMS is article versions, where new, updated versions of articles can be re-reviewed and treated as new publications. 
+A unique aspect of LiveCoMS is article versions, where new, updated versions of articles can be re-reviewed and treated as new publications.
 
-Once peer reviewed, articles receive new DOI’s and are published on the LiveCoMS site as new versions. 
+Once peer reviewed, articles receive new DOI’s and are published on the LiveCoMS site as new versions.
 This allows authors to receive credit for ongoing work they do on their articles.
 
-Authors are encouraged to make updates to articles in their GitHub repositories as frequently as warranted. 
+Authors are encouraged to make updates to articles in their GitHub repositories as frequently as warranted.
 However, release of new peer-reviewed versions via LiveCoMS is warranted only when changes become particularly extensive or important.
 Thus, versioning should typically be done no more frequently than every 12 months.
 
@@ -185,20 +185,20 @@ This model of updatable papers, curated with community input, allows paper-writi
 
 LiveCoMS' focus on "living" documents, can make authorship attribution complicated as the document evolves and more people contribute.
 Our key principle is that participants should get credit for their contributions, whether they write the document, provide feedback, file issues, or participate in other ways.
-However, different types of credit may be warranted. 
+However, different types of credit may be warranted.
 In general, changes which constitute writing a significant part of the article merit authorship, but not those which only modify small portions.
 
-In order to acknowledge more minor contributors, people who offer comments/citations that are used in the paper should be listed listed on the relevant GitHub repository README Markdown file, and should be listed in the acknowledgments section of the paper. 
+In order to acknowledge more minor contributors, people who offer comments/citations that are used in the paper should be listed listed on the relevant GitHub repository README Markdown file, and should be listed in the acknowledgments section of the paper.
 However, if the current authors feel that the contributions rise to the level of authorship, they can add new authors when the next major version is submitted.
 
 Exactly what constitutes a "significant" contribution is by necessity subjective, and authors should endeavor to be generous.
-In general, LiveCoMS hopes that authors and contributors will be able to sort out these issues amicably. In some cases, editors may be able to help resolve disputes. 
+In general, LiveCoMS hopes that authors and contributors will be able to sort out these issues amicably. In some cases, editors may be able to help resolve disputes.
 We offer the following guidelines for contributors:
 - *Contributors who deserve authorship*: If contributions are particularly significant (e.g., resulting in a new section added the manuscript),
  addition to authorship may be warranted. Ideally, contributors concerned about authorship should, before contributing, discuss with existing authors whether their contribution will merit authorship.
-- *Contributions not being accepted*: If contributors are making suggestions or proposing changes which are being 
-ignored or rejected, the contributors should first strive to convince the authors and community of the contributions' merit 
-by providing sufficiently compelling data and arguments. If this fails, the lack of engagement with issues raised may become a factor considered by the editors during the review process of subsequent versions of the paper. 
+- *Contributions not being accepted*: If contributors are making suggestions or proposing changes which are being
+ignored or rejected, the contributors should first strive to convince the authors and community of the contributions' merit
+by providing sufficiently compelling data and arguments. If this fails, the lack of engagement with issues raised may become a factor considered by the editors during the review process of subsequent versions of the paper.
 - *Review of subsequent versions*: GitHub provides an automatic mechanism for tracking contributions via the GitHub repository's history. This should be examined when revised versions of the article are being considered for publication both to ensure appropriate credit is being given, and to check that authors are engaging with and addressing substantial issues raised by the community. A failure to substantively engage in discussions on issues raised may prevent new updates of the work from being accepted.
 
 # Other Policies for Submitted Articles
@@ -208,7 +208,7 @@ Authors are required to report funding sources and grant/award numbers relevant 
 
 Authors should note whether any funding could be perceived as a conflict of interest, e.g., an article describing software in which an author has a financial interest.
 
-## Licensing 
+## Licensing
 
 LiveCoMS does not request or allow any copyright transfer.
 
@@ -226,7 +226,7 @@ your work can reach and help the broadest audience possible, and
 suggest that when considering the appropriate license you [read this analysis](http://openaccess.ox.ac.uk/2013/06/13/cc-by-what-does-it-mean-for-scholarly-articles-3/).
 
 Other more restrictive licenses may be permissible as long as LiveCoMS
-has the permission to publish and excerpt from the document. 
+has the permission to publish and excerpt from the document.
 A different license might be needed if someone other than the authors has some rights to
 the material (for example, if it was previously published in another journal). Generally, we only allow a more restrictive license in
 these cases, but are happy to discuss any licensing concerns. Please ask the managing editors
@@ -244,13 +244,13 @@ https://creativecommons.org/publicdomain/zero/1.0/)."
 
 ## Prior Publication
 
-Documents should not have been submitted in the current form to another journal, or be simultaneously under consideration for publication another journal. 
-Preprints do not count as prior publication. 
-Documents that are major revisions of previously published articles are welcomed. 
+Documents should not have been submitted in the current form to another journal, or be simultaneously under consideration for publication another journal.
+Preprints do not count as prior publication.
+Documents that are major revisions of previously published articles are welcomed.
 However, authors should ensure that any material they publish in LiveCoMS is not subject to licensing restrictions (such as from another journal) which impedes its release under the selected license.
-Some journals, e.g. *Annual Reviews*, lets the authors retain the right to create derivative works, which could perhaps be exercised in preparing a review to be published in LiveCoMS. 
+Some journals, e.g. *Annual Reviews*, lets the authors retain the right to create derivative works, which could perhaps be exercised in preparing a review to be published in LiveCoMS.
 
-If an article is an adaptation of a previously published article, it must be noted in the submission cover letter and major changes noted. 
+If an article is an adaptation of a previously published article, it must be noted in the submission cover letter and major changes noted.
 Evaluating whether such changes constitute a significant revision will be part of the review process.
 
 Authors should, to the extent possible, determine the author order among themselves.  
@@ -283,7 +283,7 @@ author or authors leaves the field; in most other cases
 authors will presumably be available to designate their own successors
 or succession plan if a work is valuable to the field and will
 continue to need maintenance and the original author(s) are no longer
-willing or able to do so. 
+willing or able to do so.
 
 Thus, for these reasons, authors submitting to LiveCoMS are agreeing
 that others may take over authorship of their article (with

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -33,6 +33,6 @@
     {% if post.read_time %}
       <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
     {% endif %}
-    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 500 }}</p>{% endif %}
   </article>
 </div>


### PR DESCRIPTION
The [Author instructions] page has some weird truncations:
![image](https://user-images.githubusercontent.com/3656088/31670296-45c929b0-b325-11e7-8fa8-621592ea8c5c.png)
This is due to the [truncation limit of 160 characters in `archive-single.html`](https://github.com/livecomsjournal/livecomsjournal.github.io/blob/master/_includes/archive-single.html#L36).

This PR increases that to 500, shortens the `excerpt` for General Author Instructions, and makes edits to the first line explaining what the document does.