### PR TITLE
Fix broken links in policies; add single-sentence descriptions article types

### DIFF
--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -24,15 +24,15 @@ Currently, articles in LiveCoMS must be submitted as one of the article types no
 
 Click each type of article for more information for submitting an article of that type.
 
-- [Best Practices Guides](/best_practices/)
+- [Best Practices Guides](authors/best_practices/) lay out recommendations for best practices or key issues to consider in a particular area of computational molecular science.
 
-- [Perpetual Reviews](/perpetual_reviews/)
+- [Perpetual Reviews](authors/perpetual_reviews/) provide a review of a particular topical area, from the author's/authors' perspective, but are maintained to reflect the latest developments.
 
-- [Comparisons of Molecular Simulation Packages](/compare_simulations/)
+- [Comparisons of Molecular Simulation Packages](authors/compare_simulations/) attempt to perform the same calculation with a range of different simulation programs. 
 
-- [Tutorials](/tutorials/)
+- [Tutorials](authors/tutorials/) provide walkthroughs or instructional materials and are acommpanied by supporting files for use as training material.
 
-- [Lessons Learned](/lessons_learned/)
+- [Lessons Learned](authors/lessons_learned/) highlight failed studies on a particular topic that are instructive/provide important lessons, helping new authors avoid mistakes encountered previously by others.
 
 # Before Submission
 


### PR DESCRIPTION
There were broken links to the article type descriptions for some reason.

This also deals with an issue raised by @oostenbrink (https://github.com/livecomsjournal/livecomsjournal.github.io/issues/62#issuecomment-337292684):
> At the top, where we have the specific links to the 'Types of Articles'. I guess it would be nice if there is a one line explanation what each of these are. Not everyone will immediately understand the difference between 'best practices' and 'lessons learned'.