### PR TITLE
Add draft instructions for editors

### DIFF
--- a/_editorial_policies/02_editor_instructions.md
+++ b/_editorial_policies/02_editor_instructions.md
@@ -1,0 +1,44 @@
+---
+layout: single
+sidebar:
+  nav: editor_instructions.md
+title: Instructions for Editors
+excerpt: Instructions for editors
+permalink: /policies/editor_instructions/
+---
+
+This provides instructions to editors handling manuscripts for LiveCoMS.
+
+## Workflow overview
+
+Authors contact LiveCoMS (specifically, the Lead Editor in a particular subject area) with a presubmission letter, proposing an article in a particular area.
+Once this is approved, they proceed with article preparation and ultimately submit it to that section of LiveCoMS.
+The Lead Editor then checks that the article is consistent with what was proposed in the presubmission letter, and then assigns it to an appropriate Associate Editor who manages the review process and makes a final decision on the manuscript, reporting the final decision to the authors.
+
+## Pre-review processing
+
+### Lead Editor
+
+The Lead Editor:
+- Handles analysis of presubmission inquiries
+- On article submission, confirms that the article is consistent with the presubmission letter
+- Passes the article and presubmission letter to an appropriate Associate Editor to manage the review process (unless he or she decides to manage the review process directly)
+
+### Associate Editor
+
+Before assigning manuscripts for review, editors have several main tasks:
+- Ensure they do not have a conflict of interest with respect to the work they are to analyze; if they do, [dealing with as dictated by editorial policy](https://livecomsjournal.github.io/policies/editorial_board/).
+- Check to ensure that the manuscript has appropropriate style, grammar, layout, and figure quality to be ready for editing, as in the [instructions for authors](https://livecomsjournal.github.io/authors/policies/). Remember, the journal will not be editing the manuscript, so if you will need to reject the manuscript (for additional revision) because of grammar issues or other stylistic reasons, you should do this *before* sending it for review to avoid wasting the time of the reviewers.
+- Identify suitable reviewers, who may include experts suggested by the authors, others in the field you already know of, or authors cited frequently in the article. LiveCoMS generally requires at least two reviewers, though exceptional circumstances (such as extensive community feedback via GitHub) may result in exceptions.
+
+## Review handling
+
+Once an editor has handled the pre-review steps described above, the review process is largely similar to typical journals. The editor:
+- Contacts suitable reviewers to request reviews, giving them a reasonable but not extended amount of time to provide their reviews and noting our conflict of interest policy
+- Handles any potential conflict of interests disclosed by reviewers consistent with (editorial policy](https://livecomsjournal.github.io/policies/editorial_board/)
+- Makes reviewers aware of the [review criteria](https://livecomsjournal.github.io/authors/policies/), including category-specific review criteria
+- Performs a check that the GitHub repository is in order, or ensure the reviewers do so.
+- Ensures reviews are submitted and analyzed in a timely manner, reaching out to remind reviewers as needed and solicit additional reviews if reviewers are too slow or their analysis conflicts
+- Potentially helps ensure reviewer feedback is fair
+- Makes a decision relating to acceptance, acceptance with minor or major revision, or rejection (keeping in mind the content of the presubmission letter), and communicates this decision to the authors (involving the Lead Editor as needed depending on the nature of the decision)
+- If the decision is that the authors must revise, provides appropriate direction about which comments to address if needed


### PR DESCRIPTION
This adds draft instructions for editors; not entirely certain I've gotten it to behave properly with the headers/etc., but at least the content is what I intend.

The idea here is to supplement what we're working on in #86 with something which actually tells editors what to do when they get a manuscript. We will probably need similar content for reviewers.

**We need to sort out whether we are going to tell the associate editor to make a decision after receiving the reviews**, or to report back to the Lead Editor and have the lead make the decision. The current draft of the bylaws in #86 is somewhat ambiguous but if anything implies that the associate just reports back. I'm not a huge fan of this (except if the associate thinks it's needed!) since it just adds an extra step which means more delay. My suggestion would be that we have the associate just decide directly, unless the decision is to reject, in which case the Lead should be brought in (since the Lead approved the presubmission letter). OK with me adjusting this AND the bylaws (#86) along those lines, @mrshirts ? 

I'll open a separate issue about what information editors will send to authors when they request reviews.