### PR TITLE
Add a brief overview of the author process to the main authors page.

### DIFF
--- a/_author_instructions/index.md
+++ b/_author_instructions/index.md
@@ -9,6 +9,13 @@ header:
 excerpt: "Author instructions"
 ---
 
+LiveCoMS handles several different types of manuscripts including [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/), [Perpetual Reviews](https://livecomsjournal.github.io/authors/perpetual_reviews/), [Comparisons of Molecular Simulation Packages](https://livecomsjournal.github.io/authors/compare_simulations/), and [Tutorials](https://livecomsjournal.github.io/authors/tutorials/).
+Authors wishing to submit to LiveCoMS should briefly review our [guidelines for authors](https://livecomsjournal.github.io/authors/policies/) and send a pre-submission inquiry to the appropriate [Lead Editor](http://www.livecomsjournal.org/editorial-board).
+Once this is approved, a brief overview of the process is as follows:
+- Prepare your manuscript in LaTeX using a suitable public GitHub repository, using our [LaTeX template](https://github.com/livecomsjournal/article_templates) appropriate for your article type, making sure you adhere to the relevant direction in our [General Author Instructions](https://livecomsjournal.github.io/authors/policies/) as well as the instructions specific to your article type (linked below).
+- Carefully edit and check the format of your article, since LiveCoMS will neither editor nor typeset your article for you
+- Submit a PDF of your final version via the [LiveCoMS website](livecomsjournal.org).
+
 {% for collection in site.collections %}
   {% if collection.label == "author_instructions" %}
     {% for post in collection.docs %}


### PR DESCRIPTION
This attempts to resolve the remaining issue of #45, and especially [this comment](https://github.com/livecomsjournal/livecomsjournal.github.io/issues/45#issuecomment-332645002) by adding a concise set of author-oriented instructions to the main author info page. Right now, we mainly only have POLICIES for authors (which implies instructions, but it doesn't lay them out in that useful a way). This provides concise instructions with links.

If merged it will close #45 .