### PR TITLE
Add README.md to repo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# LiveCoMS content
+
+This repository provides public-facing access to the content of the [author instruction/policy pages for the Living Journal of Computational Molecular Molecular Science (LiveCoMS)](https://livecomsjournal.github.io).
+
+The journal itself is published via Scholastica at [livecomsjournal.org](http://livecomsjournal.org), but full author instructions and policy information are maintained at [livecomsjournal.github.io](https://livecomsjournal.github.io) and this repository provides access to edit the content of the latter site.
+
+## Contacts
+
+If you have questions or concerns, please use our issue tracker here, or contact the managing editors at [managing@livecomsjournal.org](mailto:managing@livecomsjournal.org).


### PR DESCRIPTION
Adds a README.md to the repo so that people who visit this GitHub repo will know what they are looking at (e.g. to avoid confusion/point to livecomsjournal.github.io or livecomsjournal.org as appropriate).

Has some overlap with #104 in that this would be a logical place to put or link to instructions on rebuilding content for the website.