### PR TITLE
[WIP] Add draft of letters/reviewer information, per issue 91

### DIFF
--- a/_editorial_policies/03_reviewer_information.md
+++ b/_editorial_policies/03_reviewer_information.md
@@ -108,4 +108,4 @@ As you make the recommended changes, we also encourage you to make a final check
 Thank you again for joining with us in this exciting new publishing enterprise!
 
 Sincerely,
-`Fill in editor name`
+`{{SENDER-FULL-NAME}}`

--- a/_editorial_policies/03_reviewer_information.md
+++ b/_editorial_policies/03_reviewer_information.md
@@ -1,0 +1,106 @@
+---
+layout: single
+sidebar:
+  nav: reviewer_information.md
+title: Information for Reviewers
+excerpt: Information for reviewers
+permalink: /policies/reviewer_information/
+---
+
+This provides information relevant to reviewers of LiveCoMS, as well as a copy of the form letters that we typically use when corresponding with reviewers.
+
+
+## Brief overview of the review process
+
+Before sending manuscripts for review, a lead editor of the relevant LiveCoMS section will have responded favorably to a [presubmission inquiry](https://livecomsjournal.github.io/authors/policies/#presubmission-letter) and then checked that the submitted manuscript indeed conforms to what was originally proposed.
+A LiveCoMS editor will also have checked that the manuscript appears to be reasonably well edited and ready for review.
+Given this preparation, LiveCoMS asks that reviewers respond promptly to review requests and take immediate action on reviewing manuscripts; typically we ask that reviews be returned within 10 days, though exceptions can be made in some cases.
+The review process is in general similar to typical journals, in that we seek to ensure manuscripts are of high quality and will provide significant benefits to the field.
+However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.
+We also have a Conflict of Interest policy and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
+
+Because we are attempting to make LiveCoMS as open as possible, we provide examples below of typical form letters used for correspondence with reviewers.
+
+## Reviewer letters
+
+### Sample review request letter
+
+Dear XYZ,
+
+We invite you to review the article indicated below, which has been submitted to the `YYY` category of the [Living Journal of Computational Molecular Science](http://livecomsjournal.org) (LiveCoMS).
+LiveCoMS is a brand new and rather unique journal, which focuses on promoting best practices in molecular computation via updateable educational articles of various kinds - tutorials, reviews, best-practices “manuals” and “lessons learned” articles.
+The journal is low-cost, non-profit and run by members of our community in a transparent way; in part, it aims to provide academic credit for important work that often goes unrewarded.
+One unique feature of the review process is the requirement for a student review of every article.
+
+To ACCEPT: `link`
+To DECLINE: `link`
+
+Reviews are generally expected within 10 days, although extra time may be allowable upon request.
+
+Please be sure you review and understand our [conflict of interest policies](FILL IN LINK) before making a decision on whether or not to accept this review request.
+
+If you have any questions, please reply to this email.
+
+Thank you very much.
+`{{SENDER-FULL-NAME}}`, Associate Editor
+
+`{{MANUSCRIPT-TITLE}}`
+Abstract:
+(abstract will be automatically included)
+
+
+### Sample review action/thanks for agreeing letter
+
+(Each category has its own form letter, differing in the link to category-specific review criteria. The below sample is for Best Practices Guides)
+
+Dear XYZ,
+
+Thank you very much for agreeing to review the LiveCoMS submission, `{{MANUSCRIPT-TITLE}}`.
+Your support of our new community-run journal is very encouraging.
+
+I would appreciate receiving your review within 10 days, by `TTTTTT`.
+
+The article is to be considered under the `YYY` category.
+To aid you in your review, both the general [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and the criteria specific to [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/) are appended below.
+
+Please read our conflict-of-interest criteria and inform me of any potential conflicts.
+
+Note also that non-anonymous feedback can be provided directly to authors via the github page linked in the manuscript.
+
+If you have any questions, please reply to this email.
+
+Thank you very much.
+`{{SENDER-FULL-NAME}}`, Associate Editor
+
+REVIEW CRITERIA
+`Fill in current general review criteria`
+`Fill in current category-specific review criteria`
+
+### Reviewer ranking questions
+
+(All fields will be communicated to the authors except comments to the editor)
+- Overall rating (one to five stars)
+- For this manuscript I recommend (Accept/Revise and resubmit/Reject)
+- How well does the manuscript meet overall review criteria and category-specific criteria?
+- Is the paper adequately edited?
+- Given that the accepted PDF will be the final version of the manuscript, are there formatting, style, or quality issues which should be addressed before acceptance? What about the quality of the figures, layout of any tables, etc.?
+- Comments to the editor
+
+
+## Sample decision letter
+
+Following is a sample decision letter which might be used for communicating the outcome of the review process to the authors.
+
+Dear `{{AUTHOR-FULL-NAME}}`,
+
+Thank you very much for your submission of your article, `{{MANUSCRIPT-TITLE}}`, to the Living Journal of Computational Molecular Sciences.
+We are delighted to inform you that we anticipate being able to accept your article, pending satisfactory completion of minor revisions as recommended by the reviewers (and detailed below).
+As you make the recommended changes, we also encourage you to make a final check that:
+- The article is well edited and all images and tables are of high quality and well laid out
+- Your final submitted PDF is in fact how you want your article to appear in its final version, as the journal does not typeset or alter the formatting of your article
+- Your GitHub repository is in order and ready to accept feedback from readers
+
+Thank you again for joining with us in this exciting new publishing enterprise!
+
+Sincerely,
+`Fill in editor name`

--- a/_editorial_policies/03_reviewer_information.md
+++ b/_editorial_policies/03_reviewer_information.md
@@ -19,6 +19,11 @@ The review process is in general similar to typical journals, in that we seek to
 However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.
 We also have a Conflict of Interest policy and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
 
+One potentially unique aspect of the LiveCoMS review process is the opportunity to engage with authors publicly rather than anonymously if you so desire.
+Specifically, if you (as a reviewer) are interested in participating public discussion of the work and helping to improve it, you are free to comment on the issue tracker connected to the GitHub repository associated with the article, which can be a way to work together with the community to help authors improve their article.
+If you choose to do this, you are welcome to cross-reference GitHub comments in your review for LiveCoMS.
+
+
 Because we are attempting to make LiveCoMS as open as possible, we provide examples below of typical form letters used for correspondence with reviewers.
 
 ## Reviewer letters
@@ -65,7 +70,7 @@ To aid you in your review, both the general [review criteria](https://livecomsjo
 
 Please read our conflict-of-interest criteria and inform me of any potential conflicts.
 
-Note also that non-anonymous feedback can be provided directly to authors via the github page linked in the manuscript.
+Note also that non-anonymous feedback can be provided directly to authors via the GitHub page linked in the manuscript, if you so desire.
 
 If you have any questions, please reply to this email.
 


### PR DESCRIPTION
We need to put draft template letters to reviewers (and a draft decision letter) somewhere; probably here is as good a place as any.

This begins to resolve issue #91 by adding a new page with reviewer letters/review information. It is probably mostly ready to go, except that it *shouldn't be merged until the bylaws/conflict of interest policy are in place so it can link to them*. But it's ready for feedback/comments/edits.

Drafts are basically based on those provided in #91, except that I also added a draft decision letter since we didn't have one yet.