### PR TITLE
Tweak bylaws draft for consistency

### DIFF
--- a/_editorial_policies/01_bylaws.md
+++ b/_editorial_policies/01_bylaws.md
@@ -3,7 +3,7 @@ layout: single
 sidebar:
   nav: policies_bylaws.md
 title: Bylaws of the Living Journal of Computational Molecular Science
-excerpt: Bylaws of LiveCoMS.
+excerpt: Bylaws of LiveCoMS
 permalink: /policies/livecoms_bylaws/
 ---
 <!-- required to get the labeling right-->
@@ -38,81 +38,71 @@ permalink: /policies/livecoms_bylaws/
 
    1. Responsibilities
        1. The Managing Editors coordinate the operation of the Journal and
-          the finances of the journal, maintain the online presence.  Tasks
-          may be divided up among managing editors as they see fit, and specific
-          individual tasks may be assigned to individual associate editors.
+          the finances of the journal, maintain the online presence.
+          Tasks may be divided up among managing editors as they see fit, and specific individual tasks may be assigned to individual associate editors.
        1. Section Lead Editors handle submitted manuscripts and assign
-          all manuscripts to associate lead editors. Section lead editors make decisions on
-          presubmission letters proposing manuscripts, in which they
-          may be advised by the associate editors. Section lead editors make final decisions
-          based on recommendations from the associate editors, and communicate
-          them to the authors.
+          all manuscripts to associate lead editors.
+          Section Lead Editors make decisions on presubmission letters proposing manuscripts, in which they may be advised by the associate editors.
+          Section lead editors make final decisions based on recommendations from the associate editors, and communicate them to the authors.
        1. Associate Editors assign manuscripts to reviewers, collect
           these reviews, and make recommendations to the Section Lead
           Editors about acceptance, rejection, or requests for revision.
-       1. The Recording Secretary will coordinate and maintain confidentiality of
-          votes of the Editorial Board and record minutes of meetings of the Editorial Board.
+       1. The Recording Secretary will coordinate and maintain confidentiality of votes of the Editorial Board and record minutes of meetings of the Editorial Board.
 
    1. Selection process
        1. Members of the Editorial Board will be elected by a two-thirds vote of the Editorial Board.
-         1. Managing editors and section lead editors will be elected by a two-thirds vote of the
-            entire Editorial Board by the other current members of the Editorial Board when there is a
-            vacancy in either capacity.
+         1. Managing Editors and Section Lead Editors will be elected by a two-thirds vote of the entire Editorial Board by the other current members of the Editorial Board when there is a vacancy in either capacity.
          1. Associate editors will be elected based on:
             1. Demonstrated scholarly expertise in computational molecular science, broadly defined.
-            1. Stated commitment to contribute to decision making and maintenance of LiveCoMS.
-            1. Candidates will be favored who have shown excellence in reviewing for LiveCoMS,
-	    based on independent evaluations
-	    of the members of the Editorial Board, and who have a history of contributing manuscripts to LiveCoMS.
+            1. Stated commitment to contribute to the decision making and maintenance of LiveCoMS.
+            1. Candidates will be favored who have shown excellence in reviewing for LiveCoMS, based on independent evaluations of the members of the Editorial Board, and who have a history of contributing manuscripts to LiveCoMS.
             1. Diversity in career background, geographical perspectives, life experiences, and any other factors that are seen as beneficial to represent the broader community, provide fairness in decisions, and include a range of viewpoints.
-	    1. All members on the Editorial Board shall be elected in a fair, impartial, and confidential process without regard to race, nationality, religion, gender or gender identity, sexual orientation, or familial status.
-         1. Managing editors will be elected based on:
-            1. all criteria outlined for associate editors, plus demonstrated excellence serving as an associate editor.
-	 1. The Recording Secretary will be nominated by the Managing editors from among the associate editors.
-   1. Appointments Terms
-      1. Appointment for all positions are for three years, which may be extended for an unlimited
-	 number of terms by a vote of two/thirds of the remaining Editorial Board. If the terms of more
-         than one third of the Editorial Board end at the same time, all may remain in their positions for
-         long enough for additional editors be appointed, or one month, which ever comes first.
-      2. At the time the bylaws are adopted, the three managing editorial terms will be for two, three, and four years,
-         determined by mutual agreement or random chance if no agreement is reached.
+	    1. All members on the Editorial Board shall be elected in a fair, impartial, and confidential process without regard to race, nationality, religion, gender or gender identity, sexual orientation, or familial or economic status.
+         1. Managing Editors will be elected based on:
+            1. all criteria outlined for Associate Editors, plus demonstrated excellence serving as an Associate Editor.
+	 1. The Recording Secretary will be nominated by the Managing Editors from among the Associate Editors.
+   1. Appointment Terms
+      1. Appointment for all positions are for three years, which may be extended for an unlimited number of terms by a vote of two/thirds of the remaining Editorial Board.
+      If the terms of more than one third of the Editorial Board end at the same time, all may remain in their positions for long enough for additional editors be appointed, or one month, which ever comes first.
+      2. At the time the bylaws are adopted, initial terms for the three Managing Editors will be for two, three, and four years, determined by mutual agreement or random chance if no agreement is reached.
    1. Voting
       1. All votes described in the bylaws are tallied based on the fraction
          of the Editorial Board responding within one week written notice
-         via e-mail or other voting mechanism approved by the managing
-         editors. In exceptional circumstances advance notice may be given
+         via e-mail or other voting mechanism approved by the Managing
+         Editors. In exceptional circumstances advance notice may be given
          of a rush decision, where the board may be given one week (or more)
          notice that their votes will be needed within a shorter window,
          such as a 12 hour window.
 
 1. Conflicts of interest
-   1. A potential "conflict of interest" is a circumstance which might affect one's ability to provide a fair and objective evaluation of a work, or which might reasonably be seen as having a likelihood of doing so by an independent outside observer. When in doubt, potential conflicts of interest should always be disclosed. Common causes of conflicts of interest, for reviewers and editors, include:
-      1. being a close co-author on a paper with an author in the previous 48 months. "Close co-author" is defined as serving as corresponding author and/or first author together, or equivalent close collaboration.  This definition was chosen to avoid overly restrictive limitations for papers with large numbers of loosely-associated contributing authors, and will have some leeway for interpretation as outlined below.
+   1. A potential "conflict of interest" is a circumstance which might affect one's ability to provide a fair and objective evaluation of a work, or which might reasonably be seen as having a likelihood of doing so by an independent outside observer.
+   When in doubt, potential conflicts of interest should always be disclosed. Common causes of conflicts of interest, for reviewers and editors, include:
+      1. being a close co-author on a paper with an author in the previous 48 months. "Close co-author" is defined as serving as corresponding author and/or first author together, or equivalent close collaboration.
+      This definition was chosen to avoid overly restrictive limitations for papers with large numbers of loosely-associated contributing authors, and will have some leeway for interpretation as outlined below.
       1. being a co-awardee on a grant at any time in the in the previous 48 months.
       1. previously serving as a undergraduate, graduate, or postdoctoral supervisor or supervisee.
       1. serving at the same institution, or if there is a potential change of institution in progress that would result in being at the same institution.
       1. having a business relationship (such as serving as a consultant for or part owner of same company) within the previous 48 months.
-  1. All reviewers are responsible for reviewing our Conflict of Interest definitions and disclosing any potential conflicts of interest to the editor handling the submission.
+  1. All reviewers are responsible for reviewing our Conflict of Interest definitions and disclosing any potential conflicts of interest to the editor handling the submission; if the reviewer believes there may actually be a conflict of interest he or she should decline to review.
 
   1. Editors will try to ensure that they select reviewers who have no potential conflicts of interest.  If the reviewer has or becomes aware of a potential conflict of interest, he or she will report it to the editor so the manuscript may be reassigned. The reviewer should also disclose any co-authorship relationships from the previous 48 months, whether or not these are close co-authorships.
 
      1. If it is later discovered during the review process that a reviewer has a potential conflict of interest, the editor will assess the severity of the potential conflict (potentially in consultation with the Section Lead Editor) and potentially discard the review, seeking another.
 
-     1. If a reviewer is found to have a potential conflict of interest after a work is accepted, the handling associate editor and Section Lead Editor will evaluate whether any bias may have unduly affected the acceptance. If these editors feel they themselves may be unfairly biased, a committee of three associate editors selected by the Section Lead Editor will investigate whether any favoritism, discrimination, or fraud was intended in the review, and will follow procedures to determine whether acceptance was fraudulent as outlined by the bylaws on fraud.
+     1. If a reviewer is found to have a potential conflict of interest after a work is accepted, the handling Associate Editor and Section Lead Editor will evaluate whether any bias may have unduly affected the acceptance.
+     If these editors feel they themselves may be unfairly biased, a committee of three associate editors selected by the Section Lead Editor will investigate whether any favoritism, discrimination, or fraud was intended in the review, and will follow procedures to determine whether acceptance was fraudulent as outlined by the bylaws on fraud.
 
-   1. Parallel policies hold in the case of the section lead editor assigning an associate editor a paper.
-      1. Section lead editors will try to not assign to editors who have potential conflicts of interest, and associate editors will notify section lead editors if they are assigned a manuscript which raises potential conflict of interest concerns.  
-      1. Co-authorships that are not considered close will be reported to the section lead editors.  
-      1. If an associate editor is later discovered to have a potential conflict of interest, the manuscript will be assigned by he section lead editor to another associate editor, who will evaluate whether new reviewers should be invited.  
-      1. If a potential conflict of interest is found after acceptance, the section lead editor will evaluate whether bias may have unduly affected the acceptance. If so, a similar committee of three associate editors will investigate if the acceptance was fraudulent.
+   1. Parallel policies hold in the case of the Section Lead Editor assigning an Associate Editor a paper.
+      1. Section Lead Editors will try to not assign papers to editors who have potential conflicts of interest, and Associate Editors will notify Section Lead Editors if they are assigned a manuscript which raises potential conflict of interest concerns.  
+      1. Co-authorships that are not considered close will be reported to the Section Lead Editors.  
+      1. If an Associate Editor is later discovered to have a potential conflict of interest, the manuscript will be assigned by the Section Lead Editor to another Associate Editor, who will evaluate whether new reviewers should be invited.  
+      1. If a potential conflict of interest is found after acceptance, the Section Lead Editor will evaluate whether bias may have unduly affected the acceptance. If so, a similar committee of three Associate Editors will investigate if the acceptance was fraudulent.
 
-   1. If a Section Lead Editor has a potential conflict of interest involving a submission, the
-assignment to Associate Editors will be made by another Section Lead
-Editor.  The order of reassignment will be cyclic; if Lead Section Editor A has a
-conflict, it will got to Lead Section Editor B, unless they also have
-a potential conflict, in which case it will go to C, and so on, returning to A
-when the sections are exhausted. In the case that all of the section lead
-editors have potential conflicts, the Managing Editors will select an associate editor to assign an associate editor, with the order rotating as follows:
+   1. If a Section Lead Editor has a potential conflict of interest involving a submission, the assignment to Associate Editors will be made by another Section Lead Editor.
+   The order of reassignment will be cyclic; if Section Lead Editor A has a
+conflict, it will got to Section Lead Editor B, unless they also have a potential conflict, in which case it will go to C, and so on, returning to A
+when the sections are exhausted.
+   In the case that all of the Section Lead Editors have potential conflicts, the Managing Editors will select an Associate Editor to assign an Associate Editor, with the order rotating as follows:
       1. Comparison of Molecular Simulation Package Editor
       1. Tutorials Editor
       1. Best Practices Editor
@@ -127,19 +117,19 @@ editors have potential conflicts, the Managing Editors will select an associate 
        1. 'Plagiarism' is defined as including any clearly recognizable
 amount of text from a previous publication without attribution.
 
-       1. 'Fraud' is defined as any false representation of the circumstances of the paper or the data contained in the paper. It could include fraudulent data, or fraudulently obtained reviews (through collusion with a reviewer or editor).
+       1. 'Fraud' is defined as any false representation of the circumstances of the paper or the data contained in the paper.
+       It could include fraudulent data, or fraudulently obtained reviews (through collusion with a reviewer or editor).
 
     1. If there is a suspicion or accusation of fraud or plagiarism, a
        committee of three members of the Editorial Board will be
-       chosen by the managing editors to investigate.  
+       chosen by the Managing Editors to investigate.  
 
     1. If this committee decides unanimously that fraud or plagiarism
        occurred, then the paper will be removed from the journal, and
        the author will not be allowed to submit to LiveCoMS for at
        least three years, and must petition to the board to be allowed
-       to resubmit, which must be approved by a two-thirds vote. The
-       managing editors may notify the authors' institution of the finding
-       of fraud or plagiarism, along with evidence used to reach that finding.
+       to resubmit, which must be approved by a two-thirds vote.
+       The Managing Editors may notify the authors' institution(s) of the finding, along with associated evidence.
 
 1. Review Process
 
@@ -150,16 +140,14 @@ amount of text from a previous publication without attribution.
 
     2. Section Lead Editors make the final decision about reviews in
        consultation with the associate editor assigned to the
-       paper. In some cases, authors may appeal an editorial decision,
+       paper.
+       In some cases, authors may appeal an editorial decision,
        but initiating an appeal requires the consent of all authors.
        In case of an appeal on the decision, the Section Lead
        Editor will select another associate editor to review all
-       materials associated with the decision. If the second editor is in agreement
-       with the first editor, the decision will stand and cannot be
-       additionally appealed.  If the second editor disagrees with the
-       first decision, a third editor will be selected by the Section
-       Lead Editor, and a majority vote will be taken, which will be
-       final.
+       materials associated with the decision.
+       If the second editor is in agreement with the first editor, the decision will stand and cannot be additionally appealed.
+       If the second editor disagrees with the first decision, a third editor will be selected by the Section Lead Editor, and a majority vote will be taken, which will be final.
 
 1. Amendments
 


### PR DESCRIPTION
This tweaks the draft bylaws, mainly to improve consistency in case, e.g. "associate editor" vs "Associate Editor". Made a couple other minor clarifications, and improved use of line breaks (to improve tracking of future changes).

This is a PR to the PR of @mrshirts so if merged, it will update that PR.