### PR TITLE
Clarify 10 days for reviews

### DIFF
--- a/_editorial_policies/02_editor_instructions.md
+++ b/_editorial_policies/02_editor_instructions.md
@@ -30,7 +30,7 @@ The Lead Editor:
 Before assigning manuscripts for review, editors have several main tasks:
 - Ensure they do not have a conflict of interest with respect to the work they are to analyze; if they do, [dealing with as dictated by editorial policy](https://livecomsjournal.github.io/policies/editorial_board/).
 - Check to ensure that the manuscript has appropropriate style, grammar, layout, and figure quality to be ready for editing, as in the [instructions for authors](https://livecomsjournal.github.io/authors/policies/). Remember, the journal will not be editing the manuscript, so if you will need to reject the manuscript (for additional revision) because of grammar issues or other stylistic reasons, you should do this *before* sending it for review to avoid wasting the time of the reviewers.
-- Identify suitable reviewers, who may include experts suggested by the authors, others in the field you already know of, or authors cited frequently in the article. LiveCoMS generally requires at least two peer reviewers, plus a student reveiwer, though exceptional circumstances (such as extensive community feedback via GitHub) may result in exceptions with the consent of the Lead Editor.
+- Identify suitable reviewers, who may include experts suggested by the authors, others in the field you already know of, or authors cited frequently in the article. LiveCoMS generally requires at least two peer reviewers, plus a student reviewer, though exceptional circumstances (such as extensive community feedback via GitHub) may result in exceptions with the consent of the Lead Editor.
 
 ## Review handling
 

--- a/_editorial_policies/02_editor_instructions.md
+++ b/_editorial_policies/02_editor_instructions.md
@@ -35,7 +35,7 @@ Before assigning manuscripts for review, editors have several main tasks:
 ## Review handling
 
 Once an editor has handled the pre-review steps described above, the review process is largely similar to typical journals. The editor:
-- Contacts suitable reviewers to request reviews, giving them a reasonable (typically three weeks) but not extended amount of time to provide their reviews and noting our conflict of interest policy
+- Contacts suitable reviewers to request reviews, giving them a reasonable (typically 10 days, but exceptions can be made) but not extended amount of time to provide their reviews and noting our conflict of interest policy
 - Handles any potential conflict of interests disclosed by reviewers consistent with (editorial policy](https://livecomsjournal.github.io/policies/editorial_board/)
 - Makes reviewers aware of the [review criteria](https://livecomsjournal.github.io/authors/policies/), including category-specific review criteria
 - Performs a check that the GitHub repository is in order, or ensure the reviewers do so.


### PR DESCRIPTION
Corrects this for consistency with the review request letters we drafted; our default request is for reviews within 10 days.