### PR TITLE
Updated enumerated lists:

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -126,6 +126,19 @@ authors_lessons_learned.md:
 policies_bylaws.md:
   - title: Bylaws of the Living Journal of Computational Molecular Science
     url: /policies/livecoms_bylaws/index.html#
+    children:
+    - title: I. Organization Title and Publication
+      url: /policies/livecoms_bylaws/index.html#i-organization-title-and-publication
+    - title: II. Editorial Board
+      url: /policies/livecoms_bylaws/index.html#ii-editorial-board
+    - title: III. Conflicts of interest
+      url: /policies/livecoms_bylaws/index.html#iii-conflicts-of-interest
+    - title: IV. Fraud and Plagiarism
+      url: /policies/livecoms_bylaws/index.html#iv-fraud-and-plagiarism
+    - title: V. Review Process
+      url: /policies/livecoms_bylaws/index.html#v-review-process
+    - title: VI. Amendments
+      url: /policies/livecoms_bylaws/index.html#vi-amendments
 
 reviewing.md:
   - title: Policies About Review of Manuscripts

--- a/_editorial_policies/01_bylaws.md
+++ b/_editorial_policies/01_bylaws.md
@@ -6,150 +6,140 @@ title: Bylaws of the Living Journal of Computational Molecular Science
 excerpt: Bylaws of LiveCoMS
 permalink: /policies/livecoms_bylaws/
 ---
-<!-- required to get the labeling right-->
-<style type="text/css">
-    ol { list-style-type: upper-roman; }
-    ol ol { list-style-type: decimal; }
-    ol ol ol { list-style-type: upper-alpha; }
-    ol ol ol ol { list-style-type: lower-roman; }
-    ol ol ol ol ol { list-style-type: lower-alpha; }
-</style>
 
-1. Organization Title and Publication
+## I. Organization Title and Publication
 
-   The Journal shall be called the Living Journal of Computational
-   Molecular Science, hereafter referred to as LiveCoMS.
+The Journal shall be called the Living Journal of Computational
+Molecular Science, hereafter referred to as LiveCoMS.
 
-   LiveCoMS shall produce one publication, the Living Journal of
-   Computational Molecular Science, with articles released on a rolling
-   basis online. LiveCoMS provides a home for peer-reviewed home manuscripts
-   which advance best practices in molecular modeling and simulation. These
-   works are living documents, regularly updated with community input,
-   and can include living or perpetual reviews, tutorials, comparisons
-   between software packages, and other documents which aim to improve
-   the studies in the field and require ongoing updates.  
+LiveCoMS shall produce one publication, the Living Journal of
+Computational Molecular Science, with articles released on a rolling
+basis online. LiveCoMS provides a home for peer-reviewed home manuscripts
+which advance best practices in molecular modeling and simulation. These
+works are living documents, regularly updated with community input,
+and can include living or perpetual reviews, tutorials, comparisons
+between software packages, and other documents which aim to improve
+the studies in the field and require ongoing updates.
 
-1. Editorial Board
+## II. Editorial Board
 
-   The Editorial Board shall consist of three Managing Editors, a Section Lead
-   Editor for each type of document published in LiveCoMS, any number of
-   Associate Editors, and a Recording Secretary. Section Lead Editors may be
-   either Managing Editors or Associate Editors.
+The Editorial Board shall consist of three Managing Editors, a Section Lead
+Editor for each type of document published in LiveCoMS, any number of
+Associate Editors, and a Recording Secretary. Section Lead Editors may be
+either Managing Editors or Associate Editors.
 
-   1. Responsibilities
-       1. The Managing Editors coordinate the operation of the Journal and
-          the finances of the journal, maintain the online presence.
-          Tasks may be divided up among managing editors as they see fit, and specific individual tasks may be assigned to individual associate editors.
-       1. Section Lead Editors handle submitted manuscripts and assign
-          all manuscripts to associate lead editors.
-          Section Lead Editors make decisions on presubmission letters proposing manuscripts, in which they may be advised by the associate editors.
-          Section lead editors make final decisions based on recommendations from the associate editors, and communicate them to the authors.
-       1. Associate Editors assign manuscripts to reviewers, collect
-          these reviews, and make recommendations to the Section Lead
-          Editors about acceptance, rejection, or requests for revision.
-       1. The Recording Secretary will coordinate and maintain confidentiality of votes of the Editorial Board and record minutes of meetings of the Editorial Board.
+1. Responsibilities
+    1. The Managing Editors coordinate the operation of the Journal and
+       the finances of the journal, maintain the online presence.
+       Tasks may be divided up among managing editors as they see fit, and specific individual tasks may be assigned to individual associate editors.
+    1. Section Lead Editors handle submitted manuscripts and assign
+       all manuscripts to associate lead editors.
+       Section Lead Editors make decisions on presubmission letters proposing manuscripts, in which they may be advised by the associate editors.
+       Section lead editors make final decisions based on recommendations from the associate editors, and communicate them to the authors.
+    1. Associate Editors assign manuscripts to reviewers, collect
+       these reviews, and make recommendations to the Section Lead
+       Editors about acceptance, rejection, or requests for revision.
+    1. The Recording Secretary will coordinate and maintain confidentiality of votes of the Editorial Board and record minutes of meetings of the Editorial Board.
 
-   1. Selection process
-       1. Members of the Editorial Board will be elected by a two-thirds vote of the Editorial Board.
-         1. Managing Editors and Section Lead Editors will be elected by a two-thirds vote of the entire Editorial Board by the other current members of the Editorial Board when there is a vacancy in either capacity.
-         1. Associate editors will be elected based on:
-            1. Demonstrated scholarly expertise in computational molecular science, broadly defined.
-            1. Stated commitment to contribute to the decision making and maintenance of LiveCoMS.
-            1. Candidates will be favored who have shown excellence in reviewing for LiveCoMS, based on independent evaluations of the members of the Editorial Board, and who have a history of contributing manuscripts to LiveCoMS.
-            1. Diversity in career background, geographical perspectives, life experiences, and any other factors that are seen as beneficial to represent the broader community, provide fairness in decisions, and include a range of viewpoints.
-	    1. All members on the Editorial Board shall be elected in a fair, impartial, and confidential process without regard to race, nationality, religion, gender or gender identity, sexual orientation, or familial or economic status.
-         1. Managing Editors will be elected based on:
-            1. all criteria outlined for Associate Editors, plus demonstrated excellence serving as an Associate Editor.
-	 1. The Recording Secretary will be nominated by the Managing Editors from among the Associate Editors.
-   1. Appointment Terms
-      1. Appointment for all positions are for three years, which may be extended for an unlimited number of terms by a vote of two/thirds of the remaining Editorial Board.
-      If the terms of more than one third of the Editorial Board end at the same time, all may remain in their positions for long enough for additional editors be appointed, or one month, which ever comes first.
-      2. At the time the bylaws are adopted, initial terms for the three Managing Editors will be for two, three, and four years, determined by mutual agreement or random chance if no agreement is reached.
-   1. Voting
-      1. All votes described in the bylaws are tallied based on the fraction
-         of the Editorial Board responding within one week written notice
-         via e-mail or other voting mechanism approved by the Managing
-         Editors. In exceptional circumstances advance notice may be given
-         of a rush decision, where the board may be given one week (or more)
-         notice that their votes will be needed within a shorter window,
-         such as a 12 hour window.
+1. Selection process
+    1. Members of the Editorial Board will be elected by a two-thirds vote of the Editorial Board.
+        1. Managing Editors and Section Lead Editors will be elected by a two-thirds vote of the entire Editorial Board by the other current members of the Editorial Board when there is a vacancy in either capacity.
+    1. Associate editors will be elected based on:
+        1. Demonstrated scholarly expertise in computational molecular science, broadly defined.
+        1. Stated commitment to contribute to the decision making and maintenance of LiveCoMS.
+        1. Candidates will be favored who have shown excellence in reviewing for LiveCoMS, based on independent evaluations of the members of the Editorial Board, and who have a history of contributing manuscripts to LiveCoMS.
+        1. Diversity in career background, geographical perspectives, life experiences, and any other factors that are seen as beneficial to represent the broader community, provide fairness in decisions, and include a range of viewpoints.
+        1. All members on the Editorial Board shall be elected in a fair, impartial, and confidential process without regard to race, nationality, religion, gender or gender identity, sexual orientation, or familial or economic status.
+    1. Managing Editors will be elected based on:
+        1. all criteria outlined for Associate Editors, plus demonstrated excellence serving as an Associate Editor.
+    1. The Recording Secretary will be nominated by the Managing Editors from among the Associate Editors.
+1. Appointment Terms
+    1. Appointment for all positions are for three years, which may be extended for an unlimited number of terms by a vote of two/thirds of the remaining Editorial Board. If the terms of more than one third of the Editorial Board end at the same time, all may remain in their positions for long enough for additional editors be appointed, or one month, which ever comes first.
+    2. At the time the bylaws are adopted, initial terms for the three Managing Editors will be for two, three, and four years, determined by mutual agreement or random chance if no agreement is reached.
+1. Voting
+    1. All votes described in the bylaws are tallied based on the fraction
+       of the Editorial Board responding within one week written notice
+       via e-mail or other voting mechanism approved by the Managing
+       Editors. In exceptional circumstances advance notice may be given
+       of a rush decision, where the board may be given one week (or more)
+       notice that their votes will be needed within a shorter window,
+       such as a 12 hour window.
 
-1. Conflicts of interest
-   1. A potential "conflict of interest" is a circumstance which might affect one's ability to provide a fair and objective evaluation of a work, or which might reasonably be seen as having a likelihood of doing so by an independent outside observer.
-   When in doubt, potential conflicts of interest should always be disclosed. Common causes of conflicts of interest, for reviewers and editors, include:
-      1. being a close co-author on a paper with an author in the previous 48 months. "Close co-author" is defined as serving as corresponding author and/or first author together, or equivalent close collaboration.
-      This definition was chosen to avoid overly restrictive limitations for papers with large numbers of loosely-associated contributing authors, and will have some leeway for interpretation as outlined below.
-      1. being a co-awardee on a grant at any time in the in the previous 48 months.
-      1. previously serving as a undergraduate, graduate, or postdoctoral supervisor or supervisee.
-      1. serving at the same institution, or if there is a potential change of institution in progress that would result in being at the same institution.
-      1. having a business relationship (such as serving as a consultant for or part owner of same company) within the previous 48 months.
-  1. All reviewers are responsible for reviewing our Conflict of Interest definitions and disclosing any potential conflicts of interest to the editor handling the submission; if the reviewer believes there may actually be a conflict of interest he or she should decline to review.
+## III. Conflicts of interest
+1. A potential "conflict of interest" is a circumstance which might affect one's ability to provide a fair and objective evaluation of a work, or which might reasonably be seen as having a likelihood of doing so by an independent outside observer.
+When in doubt, potential conflicts of interest should always be disclosed. Common causes of conflicts of interest, for reviewers and editors, include:
+    1. being a close co-author on a paper with an author in the previous 48 months. "Close co-author" is defined as serving as corresponding author and/or first author together, or equivalent close collaboration.
+       This definition was chosen to avoid overly restrictive limitations for papers with large numbers of loosely-associated contributing authors, and will have some leeway for interpretation as outlined below.
+    1. being a co-awardee on a grant at any time in the in the previous 48 months.
+    1. previously serving as a undergraduate, graduate, or postdoctoral supervisor or supervisee.
+    1. serving at the same institution, or if there is a potential change of institution in progress that would result in being at the same institution.
+    1. having a business relationship (such as serving as a consultant for or part owner of same company) within the previous 48 months.
+1. All reviewers are responsible for reviewing our Conflict of Interest definitions and disclosing any potential conflicts of interest to the editor handling the submission; if the reviewer believes there may actually be a conflict of interest he or she should decline to review.
 
-  1. Editors will try to ensure that they select reviewers who have no potential conflicts of interest.  If the reviewer has or becomes aware of a potential conflict of interest, he or she will report it to the editor so the manuscript may be reassigned. The reviewer should also disclose any co-authorship relationships from the previous 48 months, whether or not these are close co-authorships.
+1. Editors will try to ensure that they select reviewers who have no potential conflicts of interest.  If the reviewer has or becomes aware of a potential conflict of interest, he or she will report it to the editor so the manuscript may be reassigned. The reviewer should also disclose any co-authorship relationships from the previous 48 months, whether or not these are close co-authorships.
 
-     1. If it is later discovered during the review process that a reviewer has a potential conflict of interest, the editor will assess the severity of the potential conflict (potentially in consultation with the Section Lead Editor) and potentially discard the review, seeking another.
+    1. If it is later discovered during the review process that a reviewer has a potential conflict of interest, the editor will assess the severity of the potential conflict (potentially in consultation with the Section Lead Editor) and potentially discard the review, seeking another.
 
-     1. If a reviewer is found to have a potential conflict of interest after a work is accepted, the handling Associate Editor and Section Lead Editor will evaluate whether any bias may have unduly affected the acceptance.
-     If these editors feel they themselves may be unfairly biased, a committee of three associate editors selected by the Section Lead Editor will investigate whether any favoritism, discrimination, or fraud was intended in the review, and will follow procedures to determine whether acceptance was fraudulent as outlined by the bylaws on fraud.
+    1. If a reviewer is found to have a potential conflict of interest after a work is accepted, the handling Associate Editor and Section Lead Editor will evaluate whether any bias may have unduly affected the acceptance.
+      If these editors feel they themselves may be unfairly biased, a committee of three associate editors selected by the Section Lead Editor will investigate whether any favoritism, discrimination, or fraud was intended in the review, and will follow procedures to determine whether acceptance was fraudulent as outlined by the bylaws on fraud.
 
-   1. Parallel policies hold in the case of the Section Lead Editor assigning an Associate Editor a paper.
-      1. Section Lead Editors will try to not assign papers to editors who have potential conflicts of interest, and Associate Editors will notify Section Lead Editors if they are assigned a manuscript which raises potential conflict of interest concerns.  
-      1. Co-authorships that are not considered close will be reported to the Section Lead Editors.  
-      1. If an Associate Editor is later discovered to have a potential conflict of interest, the manuscript will be assigned by the Section Lead Editor to another Associate Editor, who will evaluate whether new reviewers should be invited.  
-      1. If a potential conflict of interest is found after acceptance, the Section Lead Editor will evaluate whether bias may have unduly affected the acceptance. If so, a similar committee of three Associate Editors will investigate if the acceptance was fraudulent.
+1. Parallel policies hold in the case of the Section Lead Editor assigning an Associate Editor a paper.
+    1. Section Lead Editors will try to not assign papers to editors who have potential conflicts of interest, and Associate Editors will notify Section Lead Editors if they are assigned a manuscript which raises potential conflict of interest concerns.
+    1. Co-authorships that are not considered close will be reported to the Section Lead Editors.
+    1. If an Associate Editor is later discovered to have a potential conflict of interest, the manuscript will be assigned by the Section Lead Editor to another Associate Editor, who will evaluate whether new reviewers should be invited.
+    1. If a potential conflict of interest is found after acceptance, the Section Lead Editor will evaluate whether bias may have unduly affected the acceptance. If so, a similar committee of three Associate Editors will investigate if the acceptance was fraudulent.
 
-   1. If a Section Lead Editor has a potential conflict of interest involving a submission, the assignment to Associate Editors will be made by another Section Lead Editor.
-   The order of reassignment will be cyclic; if Section Lead Editor A has a
-conflict, it will got to Section Lead Editor B, unless they also have a potential conflict, in which case it will go to C, and so on, returning to A
-when the sections are exhausted.
-   In the case that all of the Section Lead Editors have potential conflicts, the Managing Editors will select an Associate Editor to assign an Associate Editor, with the order rotating as follows:
-      1. Comparison of Molecular Simulation Package Editor
-      1. Tutorials Editor
-      1. Best Practices Editor
-      1. Review Editor
-      1. Lessons Learned Editor
-      1. continuing with editors of other sections, in order they are chronologically added to the journal.
+1. If a Section Lead Editor has a potential conflict of interest involving a submission, the assignment to Associate Editors will be made by another Section Lead Editor.
+The order of reassignment will be cyclic; if Section Lead Editor A has a
+flict, it will got to Section Lead Editor B, unless they also have a potential conflict, in which case it will go to C, and so on, returning to A
+n the sections are exhausted.
+In the case that all of the Section Lead Editors have potential conflicts, the Managing Editors will select an Associate Editor to assign an Associate Editor, with the order rotating as follows:
+    1. Comparison of Molecular Simulation Package Editor
+    1. Tutorials Editor
+    1. Best Practices Editor
+    1. Review Editor
+    1. Lessons Learned Editor
+    1. continuing with editors of other sections, in order they are chronologically added to the journal.
 
-1. Fraud and Plagiarism
+## IV. Fraud and Plagiarism
 
-    1. Definitions:
+1. Definitions:
 
-       1. 'Plagiarism' is defined as including any clearly recognizable
-amount of text from a previous publication without attribution.
+    1. 'Plagiarism' is defined as including any clearly recognizable amount of text from a previous publication without attribution.
 
-       1. 'Fraud' is defined as any false representation of the circumstances of the paper or the data contained in the paper.
+    1. 'Fraud' is defined as any false representation of the circumstances of the paper or the data contained in the paper.
        It could include fraudulent data, or fraudulently obtained reviews (through collusion with a reviewer or editor).
 
-    1. If there is a suspicion or accusation of fraud or plagiarism, a
-       committee of three members of the Editorial Board will be
-       chosen by the Managing Editors to investigate.  
+1. If there is a suspicion or accusation of fraud or plagiarism, a
+   committee of three members of the Editorial Board will be
+   chosen by the Managing Editors to investigate.
 
-    1. If this committee decides unanimously that fraud or plagiarism
-       occurred, then the paper will be removed from the journal, and
-       the author will not be allowed to submit to LiveCoMS for at
-       least three years, and must petition to the board to be allowed
-       to resubmit, which must be approved by a two-thirds vote.
-       The Managing Editors may notify the authors' institution(s) of the finding, along with associated evidence.
+1. If this committee decides unanimously that fraud or plagiarism
+   occurred, then the paper will be removed from the journal, and
+   the author will not be allowed to submit to LiveCoMS for at
+   least three years, and must petition to the board to be allowed
+   to resubmit, which must be approved by a two-thirds vote.
+   The Managing Editors may notify the authors' institution(s) of the finding, along with associated evidence.
 
-1. Review Process
+## V. Review Process
 
-    1. Review criteria that editors use shall be posted on the author
-       instructions section of the website. These review criteria will be
-       revised for clarity periodically in response to feedback, with the
-       approval of the Section Lead Editor.
+ 1. Review criteria that editors use shall be posted on the author
+    instructions section of the website. These review criteria will be
+    revised for clarity periodically in response to feedback, with the
+    approval of the Section Lead Editor.
 
-    2. Section Lead Editors make the final decision about reviews in
-       consultation with the associate editor assigned to the
-       paper.
-       In some cases, authors may appeal an editorial decision,
-       but initiating an appeal requires the consent of all authors.
-       In case of an appeal on the decision, the Section Lead
-       Editor will select another associate editor to review all
-       materials associated with the decision.
-       If the second editor is in agreement with the first editor, the decision will stand and cannot be additionally appealed.
-       If the second editor disagrees with the first decision, a third editor will be selected by the Section Lead Editor, and a majority vote will be taken, which will be final.
+ 2. Section Lead Editors make the final decision about reviews in
+    consultation with the associate editor assigned to the
+    paper.
+    In some cases, authors may appeal an editorial decision,
+    but initiating an appeal requires the consent of all authors.
+    In case of an appeal on the decision, the Section Lead
+    Editor will select another associate editor to review all
+    materials associated with the decision.
+    If the second editor is in agreement with the first editor, the decision will stand and cannot be additionally appealed.
+    If the second editor disagrees with the first decision, a third editor will be selected by the Section Lead Editor, and a majority vote will be taken, which will be final.
 
-1. Amendments
+## VI. Amendments
 
    These bylaws may be amended by two-thirds of the vote of the entire
-   Editorial Board.  
+   Editorial Board.

--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -124,6 +124,12 @@
     margin-top: -1.5em;
     padding-left: 1.25rem;
   }
+
+  /* defines enumerated lists */
+  ol { list-style-type: decimal; }
+  ol ol { list-style-type: upper-alpha; }
+  ol ol ol { list-style-type: lower-roman; }
+  ol ol ol ol { list-style-type: lower-alpha; }
 }
 
 .page__hero {


### PR DESCRIPTION
- Changed upper-most enumerated levels to second-level titles, thereby
   incorporating the numbering explicitly in the title.
- Shifted enumeration levels one level up (since upper-most levels are
  not enumerated lists anymore, but headers).
- Moved enumeration css-snippet into general page css.
- Some whitespace changes to unify indentation levels.

This has the down-side of not having automatic enumeration anymore
(need to change titles by hand if a new subtitle is inserted), but
has a number of advantages, namely that they look like headers
(there does not seem to be a way to do that in standard Markdown /
Jekyll otherwise), and that the enumeration scheme (1. / A. / i. / a.)
is now general enough to move it to a general css file.