### PR TITLE
How to include presubmission letter 

### DIFF
--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -171,9 +171,10 @@ When ready for submission, the author uploads the final article PDF (created usi
 The authors must also submit with the final article PDF:
 
   * A cover letter with suggestions for 4--5 reviewers and that notes any deviations from what was laid out in the presubmission letter.  Reviewers will also be entered on the submission form.
-  * As a single PDF file, a copy of the presubmission letter, appended with the response recieved from the Section Lead Editor approving the presubmission and specifying any changes or modifications to the scope. This should be uploaded as a "Supporting File", with the descriptor "Presubmission Letter"  
+  * As a single PDF file, a copy of their presubmission letter, appended with the response recieved from the Section Lead Editor approving the presubmission and specifying any changes or modifications to the scope the editors requested.
+This should be uploaded as a "Supporting File", with the descriptor "Presubmission Letter"
   * A representative image as noted above which will appear on the article's page on the journal.
-  * Any Supporting Files that are intended for distribution with the final paper should also be uploaded at this time. There is no explicit limit to the number of files, though if there are many similar data files, they should be uploaded as a `.tgz'ed or `.zip`ed directory and include a README.md or README.txt file.  
+  * Any Supporting Files that are intended for distribution with the final paper should also be uploaded at this time. There is no explicit limit to the number of files that can be added, though if there are many similar data files, they should be uploaded as a `.tgz'ed or `.zip`ed directory and include a README.md or README.txt file.
 
 Article submission also involves paying a nominal charge of of $100 per submission, which covers our peer review management system as well as ongoing operation costs (web hosting, etc.).
 This is handled through Stripe Connect and can be paid via any major credit card.

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -168,8 +168,12 @@ Posting to a preprint server can be done at any time prior to submission.
 When ready for submission, the author uploads the final article PDF (created using the [LiveCoMS templates](https://github.com/livecomsjournal/article_templates), discussed above) and a link to the GitHub site for the article.
 [Full submission instructions are available through Scholastica](http://help.scholasticahq.com/customer/portal/articles/1218626), our journal management system.
 
-The authors must also submit a cover letter with suggestions for 4--5 reviewers and note any deviations from the presubmission letter.
-Additionally, you must upload a representative image as noted above.
+The authors must also submit with the final article PDF:
+
+  * A cover letter with suggestions for 4--5 reviewers and that notes any deviations from what was laid out in the presubmission letter.  Reviewers will also be entered on the submission form.
+  * As a single PDF file, a copy of the presubmission letter, appended with the response recieved from the Section Lead Editor approving the presubmission and specifying any changes or modifications to the scope. This should be uploaded as a "Supporting File", with the descriptor "Presubmission Letter"  
+  * A representative image as noted above which will appear on the article's page on the journal.
+  * Any Supporting Files that are intended for distribution with the final paper should also be uploaded at this time. There is no explicit limit to the number of files, though if there are many similar data files, they should be uploaded as a `.tgz'ed or `.zip`ed directory and include a README.md or README.txt file.  
 
 Article submission also involves paying a nominal charge of of $100 per submission, which covers our peer review management system as well as ongoing operation costs (web hosting, etc.).
 This is handled through Stripe Connect and can be paid via any major credit card.

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -170,11 +170,11 @@ When ready for submission, the author uploads the final article PDF (created usi
 
 The authors must also submit with the final article PDF:
 
-  * A cover letter with suggestions for 4--5 reviewers and that notes any deviations from what was laid out in the presubmission letter.  Reviewers will also be entered on the submission form.
+  * A cover letter with suggestions for 4-5 reviewers and that notes any deviations from what was laid out in the presubmission letter.  Reviewers will also be entered on the submission form.
   * As a single PDF file, a copy of their presubmission letter, appended with the response recieved from the Section Lead Editor approving the presubmission and specifying any changes or modifications to the scope the editors requested.
 This should be uploaded as a "Supporting File", with the descriptor "Presubmission Letter"
   * A representative image as noted above which will appear on the article's page on the journal.
-  * Any Supporting Files that are intended for distribution with the final paper should also be uploaded at this time. There is no explicit limit to the number of files that can be added, though if there are many similar data files, they should be uploaded as a `.tgz'ed or `.zip`ed directory and include a README.md or README.txt file.
+  * Any Supporting Files that are intended for distribution with the final paper should also be uploaded at this time. There is no explicit limit to the number of files that can be added, though if there are many similar data files, they should be uploaded as a `.tgz`ed or `.zip`ed directory and include a README.md or README.txt file.
 
 Article submission also involves paying a nominal charge of of $100 per submission, which covers our peer review management system as well as ongoing operation costs (web hosting, etc.).
 This is handled through Stripe Connect and can be paid via any major credit card.


### PR DESCRIPTION
There was a discussion in the editorial board call about how to have the presubmission letter included.  I investigated this and added that information to the author instructions, as contained in this PR (plus some additional details for supporting files).