### PR TITLE
[WIP] Adding reviewer instructions and criteria

### DIFF
--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -190,8 +190,10 @@ Authors are also encouraged to have other researchers review their content, with
 ## Reviewer instructions and review criteria
 
 Reviews will by default be anonymous, but reviewers will be allowed to make themselves known if they desire.
-For example, reviewers can participate directly in revisions through the GitHub website.
-For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly. This open revision approach may be particularly suitable for articles which will become community resources. Reviewers who choose to remain anonymous may also participate via GitHub issues, though it may be possible for authors to intuit reviews from their GitHub comments.
+
+Reviewers, if they wish, can participate directly in revisions through the GitHub website. For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly. This open revision approach may be particularly suitable for articles which will become community resources.  While reviewers may to reference comments on the github repo, the review must contain a complete listing of all expected changes in a way that is unambiguous for authors.
+
+Reviewers who choose to remain anonymous may also participate via GitHub issues, though it may be possible for authors to intuit reviews from their GitHub comments.
 
 ## Review criteria 
 
@@ -215,9 +217,7 @@ A unique aspect of LiveCoMS is article versions, where new, updated versions of 
 Once peer reviewed, articles receive new [digital object identifiers (DOIs)](https://www.doi.org/) and are published on the LiveCoMS site as new versions.
 This allows authors to receive credit for ongoing work they do on their articles.
 
-Authors are encouraged to make updates to articles in their GitHub repositories as frequently as warranted.
-However, release of new peer-reviewed versions via LiveCoMS is warranted only when changes become particularly extensive or important.
-Thus, versioning should typically be done no more frequently than every 12 months.
+Authors are encouraged to make updates to articles in their GitHub repositories as frequently as warranted. However, release of new peer-reviewed versions via LiveCoMS is warranted only when changes become particularly extensive or important. Thus, versioning should typically be done no more frequently than every 12 months.
 
 The review process for an update to a LiveCoMS article is similar to the review process for the initial version.  
 Additional review criteria will include whether or not issues the community raised on the article's issue tracker were responded to, and whether the revision includes sufficient new material.

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -180,25 +180,27 @@ This is handled through Stripe Connect and can be paid via any major credit card
 
 ## The review process
 
-The review process generally begins with an editor reviewing your document to check that it is ready for review (e.g., that it uses suitable English, is laid out appropriately and legibly, etc.) and subsequently selecting reviewers.
-If there are major issues at this stage, your article may be returned for revision prior to review.
-Reviews will generally be anonymous, though reviewers will be allowed to make themselves known if they desire.
-Reviewers can also participate directly in revisions through the GitHub website, whether or not they remain anonymous.
-For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly.
-This open revision approach may be particularly suitable for articles which will become community resources.
-
-## Review criteria
+The review process generally begins with an editor reviewing your document to check that it is ready for review (e.g., that it uses suitable English, is laid out appropriately and legibly, etc.) and subsequently selecting reviewers. If there are major issues at this stage, your article may be returned for revision prior to review.
 
 A key purpose of the articles is that they should be useful to a range of researchers, but especially beginning researchers.
 Thus, all submitted manuscripts will be reviewed by a member of the student review board, which consists of graduate students and postdocs invited by the editorial board.
 
-Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.  
-A history of revisions in response to community concerns will impact the review process favorably.
+Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.   A history of revisions in response to community concerns will impact the review process favorably.
 
-Reviewers will also be asked to assess whether articles are well edited and clearly written.
-Authors whose article uses inconsistent style or poor grammar, or is poorly edited, may be asked to revise and address these issues.
+## Reviewer instructions and review criteria
 
-Reviews will also consider the additional factors according to manuscript category: [please see the individual category links](#types-of-articles) for more information on these review criteria.
+Reviews will by default be anonymous, but reviewers will be allowed to make themselves known if they desire.
+For example, reviewers can participate directly in revisions through the GitHub website.
+For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly. This open revision approach may be particularly suitable for articles which will become community resources. Reviewers who choose to remain anonymous may also participate via GitHub issues, though it may be possible for authors to intuit reviews from their GitHub comments.
+
+## Review criteria 
+
+Reviewers will be asked to 
+  1. Assess whether articles are well edited and clearly written.  Authors whose article uses inconsistent style or poor grammar, or is poorly edited, will be asked to revise and address these issues.
+  
+  1. More stuff. 
+
+  1. Specifically comment on consider the review criteria specific to each manuscript category: [please see the individual category links](#types-of-articles) for more information on these review criteria.
 
 
 ## The Revision Process

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -168,7 +168,7 @@ Posting to a preprint server can be done at any time prior to submission.
 When ready for submission, the author uploads the final article PDF (created using the [LiveCoMS templates](https://github.com/livecomsjournal/article_templates), discussed above) and a link to the GitHub site for the article.
 [General Scholastica submission instructions are available through on the Scholastica help page](http://help.scholasticahq.com/customer/portal/articles/1218626), our journal management system. There are a [few additional LiveCoMS submission instructions](http://www.livecomsjournal.org/for-authors).  
 
-The authors must also submit with the final article PDF:
+For the submission, along with the final article pdf:
 
   * As part of the submission form, authors will suggest 4-5 reviewers.
   * As a single PDF file, a copy of their presubmission letter, appended with the response recieved from the Section Lead Editor approving the presubmission and specifying any changes or modifications to the scope the editors requested. The authors should also include a description of deviations, if any, from what was laid out in the presubmission letter, with a rationale for why the changes were made. This should be uploaded as a "Supporting File", with the descriptor "Presubmission Letter". 


### PR DESCRIPTION
Adding reviewer instructions directly to the author policies web page - in terns of maximum transparency, seems best to put everything directly on the main web page.  Needs to be further edited before committing, but is co-evolving with the reviewer form.