### PR TITLE
Organize reviewer info

### DIFF
--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -188,7 +188,7 @@ For example, a reviewer could choose to submit a very brief review addressing on
 This open revision approach may be particularly suitable for articles which will become community resources.
 
 
-A key criteria for article in LiveCOMS is that they should be useful to a range of researchers, but especially beginning researchers.
+A key criteria for articles in LiveCOMS is that they should be useful to a range of researchers, but especially beginning researchers.
 Thus, all submitted manuscripts will be reviewed by a graduate students or postdoc invited by the editorial board.
 
 Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -170,11 +170,11 @@ When ready for submission, the author uploads the final article PDF (created usi
 
 The authors must also submit with the final article PDF:
 
-  * As part of the submission form, authors will suggest 4-5 reviewers.
   * As a single PDF file, a copy of their presubmission letter, appended with the response recieved from the Section Lead Editor approving the presubmission and specifying any changes or modifications to the scope the editors requested. The authors should also include a description of deviations, if any, from what was laid out in the presubmission letter, with a rationale for why the changes were made. This should be uploaded as a "Supporting File", with the descriptor "Presubmission Letter". 
   * An image to accompany the paper at least 300 x 200 pixels, any standard image format, color preferred, less than 1MB in size). This image is important to choose carefully, as it is the image that will appear on the article's front page and whenever the paper is shared on social media. We suggest something evocative of the research, but containing less scientific detail than, say, the table of contents image for an ACS journal.
   * Any Supporting Files that are intended for distribution with the final paper should also be uploaded at this time. There is no explicit limit to the number of files that can be added, though if there are many similar data files, they should be uploaded as a `.tgz`ed or `.zip`ed directory and include a README file.
 
+As part of the submission form, authors will suggest 4-5 reviewers.
 Article submission also involves paying a nominal charge of $100 per submission, which covers our peer review management system as well as ongoing operation costs (web hosting, etc.).
 This is handled through Stripe Connect and can be paid via any major credit card.
 
@@ -184,12 +184,19 @@ The review process generally begins with an editor reviewing your document to ch
 If there are major issues at this stage, your article may be returned for revision prior to review.
 Reviews will generally be anonymous, though reviewers will be allowed to make themselves known if they desire.
 Reviewers can also participate directly in revisions through the GitHub website, whether or not they remain anonymous.
-For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly.
+For example, a reviewer could choose to submit a very brief review addressing only suitability questions, and then provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly.
 This open revision approach may be particularly suitable for articles which will become community resources.
 
+
+A key criteria for article in LiveCOMS is that they should be useful to a range of researchers, but especially beginning researchers.
+Thus, all submitted manuscripts will be reviewed by a graduate students or postdoc invited by the editorial board.
+
+Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.
+A history of revisions in response to community concerns, questions and suggestions will impact the review process favorably.
+ 
 For more information about the role of reviewers and the criteria they are asked to use, please see the [Reviewer Information](https://livecomsjournal.github.io/policies/reviewer_information/).
 
-## The Revision Process
+## The revision process
 
 If manuscript revision is requested, authors will typically be asked to re-submit within 30 days for minor revisions and 60 days for major revisions.
 After this time, a revised manuscript may be handled as a new submission.
@@ -202,11 +209,11 @@ Once peer reviewed, articles receive new [digital object identifiers (DOIs)](htt
 This allows authors to receive credit for ongoing work they do on their articles.
 
 Authors are encouraged to make updates to articles in their GitHub repositories as frequently as warranted.
-However, release of new peer-reviewed versions via LiveCoMS is warranted only when changes become particularly extensive or important.
-Thus, versioning should typically be done no more frequently than every 12 months.
+However, release of new peer-reviewed versions via LiveCoMS is warranted only when changes become particularly extensive or important, and authors must justify why a peer-reviewed update is needed.
+As a rough guide, versioning should typically be done no more frequently than every 12 months.
 
 The review process for an update to a LiveCoMS article is similar to the review process for the initial version.  
-Additional review criteria will include whether or not issues the community raised on the article's issue tracker were responded to, and whether the revision includes sufficient new material.
+Important additional review criteria for a revision will include whether or not issues the community raised on the article's issue tracker were responded to, and whether the revision includes sufficient new material.
 
 Certain categories of article may need revision at different frequencies.
 For information on the review frequencies, see [author information for each of the types of articles](#types-of-articles).
@@ -216,7 +223,7 @@ For information on the review frequencies, see [author information for each of t
 We require GitHub use for papers as it provides an easy mechanism for community feedback on the paper, allowing questions, comments, or additions.
 Community members can easily [file issues](https://help.github.com/articles/about-issues/) on these topics, and then these can be incorporated into new versions of the article.
 This can help LiveCoMS articles truly become living documents.
-Please note: The issue tracker for these documents is not just for *problems* with the articles, but also for general discussion, feedback, questions, and so on -- basically, for any type of discussion about the article.
+Please note: The issue tracker for these documents is not just for *problems* with the articles, but also for general discussion, feedback, questions, and so on---basically, for any type of discussion about the article.
 
 We are sympathetic to the fact that some commenters may wish to provide feedback to authors outside of GitHub.
 This can be done via any suitable means, such as contacting the relevant authors directly.

--- a/_author_instructions/01_policies.md
+++ b/_author_instructions/01_policies.md
@@ -187,19 +187,7 @@ Reviewers can also participate directly in revisions through the GitHub website,
 For example, a reviewer could choose to submit a very brief review addressing only suitability, but provide extensive feedback to the authors on the GitHub issue tracker, allowing discussion of how the article should be revised to be done openly.
 This open revision approach may be particularly suitable for articles which will become community resources.
 
-## Review criteria
-
-A key purpose of the articles is that they should be useful to a range of researchers, but especially beginning researchers.
-Thus, all submitted manuscripts will be reviewed by a member of the student review board, which consists of graduate students and postdocs invited by the editorial board.
-
-Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.  
-A history of revisions in response to community concerns will impact the review process favorably.
-
-Reviewers will also be asked to assess whether articles are well edited and clearly written.
-Authors whose article uses inconsistent style or poor grammar, or is poorly edited, may be asked to revise and address these issues.
-
-Reviews will also consider the additional factors according to manuscript category: [please see the individual category links](#types-of-articles) for more information on these review criteria.
-
+For more information about the role of reviewers and the criteria they are asked to use, please see the [Reviewer Information](https://livecomsjournal.github.io/policies/reviewer_information/).
 
 ## The Revision Process
 

--- a/_author_instructions/02_best_practices.md
+++ b/_author_instructions/02_best_practices.md
@@ -37,7 +37,7 @@ training in the fundamentals of molecular simulation, and (c) mistakes made due 
 Checklists in this journal will typically focus on errors that are likely to be made by users with training and experience in molecular simulations, i.e., errors of type (a) and (b).
 As such, normal best practices documents can and should assume a basic familiarity with the fundamentals of molecular simulations.
 
-## Additional factors considered in review of best practices guides
+## [Additional factors considered in reviews of best practices guides](#review-criteria)
 Reviewers will consider the following factors in reviewing best practices guides:
 * Would following the provided checklist help users avoid significant potential errors in simulation? Will the errors be profound and/or frequent? 
 * Are all assertions well-sourced in published data (which may, in some cases, include data created for the paper)?

--- a/_author_instructions/03_perpetual_reviews.md
+++ b/_author_instructions/03_perpetual_reviews.md
@@ -15,7 +15,7 @@ al. review](https://github.com/MobleyLab/benchmarksets), which was
 originally an *Annual Reviews in Biophysics* article, but is now being
 updated regularly on GitHub.
 
-## Additional review criteria for perpetual reviews
+## [Additional review criteria for perpetual reviews](#review-criteria)
 * Do the authors properly include information from the recent literature, including last 6 to 12 months?
 * Is this a good summary of its area which will be valuable to the field?
 * Do the authors include data and viewpoints that are contradictory to their own, if these exist?

--- a/_author_instructions/04_compare_simulations.md
+++ b/_author_instructions/04_compare_simulations.md
@@ -15,7 +15,7 @@ Such comparison should be updated periodically with different versions of
 the same programs (or potentially additional programs).
 
 
-## Additional factors considered in review of comparisons of molecular simulation programs
+## [Additional factors considered in review of comparisons of molecular simulation programs](#review-criteria)
 * Does the manuscript include developers or advanced users of all programs being compared to ensure that comparisons are fair?
 * Are best practices being used in the simulation comparisons?
 * Are the methods applied to systems which for which reliable independent data are available?  Are the systems considered of sufficient complexity that readers will find the results convincing and generalizable?

--- a/_author_instructions/05_tutorials.md
+++ b/_author_instructions/05_tutorials.md
@@ -27,7 +27,7 @@ Tutorials should clearly define what system and/or software requirements the res
 **Pre-existing tutorials**: The submission of existing tutorials, so long as they meet the journal standards described here, is explicitly welcomed.
 Our goal is to encourage the development of high quality tutorials by providing some degree of academic credit for these important and time-consuming efforts.
 
-## Additional factors considered in review of tutorials
+## [Additional criteria considered in the review of tutorials](#review-criteria)
 * Are files and necessary executables required to run the tutorial posted online in a permanent (or nearly so) way?
 * Are the tutorials suitable for the intended audience (e.g., researchers with only basic knowledge or advanced researchers)?
 * Do they include enough information on how to generalize the approach to handle other cases, and highlight major issues to consider?

--- a/_author_instructions/06_lessons_learned.md
+++ b/_author_instructions/06_lessons_learned.md
@@ -20,7 +20,7 @@ The article should contain the usual sections: Introduction, including backgroun
 Data analysis should conform to [best practices](https://github.com/dmzuckerman/Sampling-Uncertainty).
 
 
-## Additional factors considered in review of "lessons learned" documents
+## [Additional factors considered in review of "lessons learned" articles](#review-criteria)
 Reviewers will consider the following factors in reviewing "lessons learned" document.
 * Is the motivation for the approach clearly described and reasonable given existing literature?
 * Are the "lessons" provided likely to be of value to a significant number of researchers, based on demonstrated broad applicability?

--- a/_editorial_policies/01_bylaws.md
+++ b/_editorial_policies/01_bylaws.md
@@ -66,7 +66,7 @@ either Managing Editors or Associate Editors.
        notice that their votes will be needed within a shorter window,
        such as a 12 hour window.
 
-## III. Conflicts of interest
+## III. [Conflicts of interest](#conficts-of-interest)
 1. A potential "conflict of interest" is a circumstance which might affect one's ability to provide a fair and objective evaluation of a work, or which might reasonably be seen as having a likelihood of doing so by an independent outside observer.
 When in doubt, potential conflicts of interest should always be disclosed. Common causes of conflicts of interest, for reviewers and editors, include:
     1. Being a close co-author on a paper with an author in the previous 36 months. "Close co-author" is defined as serving as corresponding author and/or first author together, or equivalent close collaboration.

--- a/_editorial_policies/03_reviewer_information.md
+++ b/_editorial_policies/03_reviewer_information.md
@@ -11,7 +11,7 @@ permalink: /policies/reviewer_information/
 
 Before sending manuscripts for review, a lead editor of the relevant LiveCoMS section will have responded favorably to a [presubmission inquiry](https://livecomsjournal.github.io/authors/policies/#presubmission-letter) and then checked that the submitted manuscript indeed conforms to what was originally proposed.
 A LiveCoMS editor will also have checked that the manuscript appears to be reasonably well edited and ready for review.
-Given this preparation, LiveCoMS asks that reviewers respond promptly to review requests and take immediate action on reviewing manuscripts; typically we ask that reviews be returned within 21 days.
+Given this preparation, LiveCoMS asks that reviewers respond promptly to review requests and take immediate action on reviewing manuscripts; typically we ask that reviews be returned within 15 days.
 
 The review process is in general similar to typical journals, in that we seek to ensure manuscripts are of high quality and will provide significant benefits to the field.
 However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.  Look in each section for the bullet pointed list of review criteria to consider, and respond to each of the relevant points specifically.

--- a/_editorial_policies/03_reviewer_information.md
+++ b/_editorial_policies/03_reviewer_information.md
@@ -14,23 +14,39 @@ A LiveCoMS editor will also have checked that the manuscript appears to be reaso
 Given this preparation, LiveCoMS asks that reviewers respond promptly to review requests and take immediate action on reviewing manuscripts; typically we ask that reviews be returned within 21 days.
 
 The review process is in general similar to typical journals, in that we seek to ensure manuscripts are of high quality and will provide significant benefits to the field.
-However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.  Look in each section for the bullet pointed list of review criteria to consider, and respond to each of the relevant points specifically. Additionally, consistent with its pedagogical mission, LiveCoMS requires a graduate student or postdoc review of each manuscript.
+However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.  Look in each section for the bullet pointed list of review criteria to consider, and respond to each of the relevant points specifically.
 
-We also have a [Conflicts of Interest policy](https://livecomsjournal.github.io/policies/livecoms_bylaws/#conflicts-of-interest) and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
+We also have a [Conflicts of Interest policy](https://livecomsjournal.github.io/policies/livecoms_bylaws/#conflicts-of-interest) and you as a reviewer should make sure they are familiar with these policies, and decline to review if they have a conflict.  If you are uncertain about a conflict, they should disclose any such potential conflicts to the editor managing the review process.
 
 One unique aspect of the LiveCoMS review process is the opportunity to engage with authors publicly rather than anonymously if you so desire.
 Specifically, if you (as a reviewer) are interested in participating public discussion of the work and helping to improve it, you are free to comment on the issue tracker connected to the GitHub repository associated with the article, which can be a way to work together with the community to help authors improve their article.
-If you choose to do this, it is suggested that you cross-reference GitHub comments in your review for LiveCoMS in an unambiguous way so the author knows exactly what needs to be addressed.  If you wish to remain completely anonymous, we suggest refraining from leaving GitHub comments near the time of your review, as the author will likely be able to guess your identity from the comments.
+If you choose to do this, you should cross-reference GitHub comments in your review for LiveCoMS in an unambiguous way so the author knows exactly what needs to be addressed.  If you wish to remain completely anonymous, we suggest refraining from leaving GitHub comments near the time of your review, as the author will likely be able to guess your identity from the comments.
 
+Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.   A history of revisions in response to community concerns will impact the review process favorably.
 
-A key purpose of the articles is that they should be useful to a range of researchers, but especially beginning researchers.
-Thus, all submitted manuscripts will be reviewed by a member of the student review board, which consists of graduate students and postdocs invited by the editorial board.
+Reviewers will assess whether articles are well edited and clearly written.
+Authors whose article uses inconsistent style or poor grammar, or is poorly edited, will be asked to revise and address these issues.
 
-Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.  
-A history of revisions in response to community concerns will impact the review process favorably.
+## Reviewer form
 
-Reviewers will also be asked to assess whether articles are well edited and clearly written.
-Authors whose article uses inconsistent style or poor grammar, or is poorly edited, may be asked to revise and address these issues.
+The reviewer form asks the following questions:
 
-Reviews will also consider the additional factors according to manuscript category: [please see the individual category links](#types-of-articles) for more information on these review criteria.
+*Overall Rating*
+Reviewer will rank from 1-5 stars.
 
+*For this manuscript I recommend...*
+Reviewer will choose between "Accept", "Revise and resubmit", and "Reject"
+
+The reviewer will then answer the following open response questions.  For these responses, the reviewer may also copy the questions to a separate document, respond to them there, and attach the responses.
+
+*What is the level of significance of this work and its suitability for the journal? Is it likely to have a strong positive impact on the targeted set of readers? If this is a revision, what is the significance of the updated material?"
+
+*To what extent does the article engage with current understanding in the scholarly community? If this is a revision, to what extent do the authors engage with the community participating on their GitHub version?*
+
+*In what ways should the paper be improved to be easy to read, free from grammatical errors, have a professional presentation, and meet the article formatting guidelines laid out in the [author policies](https://livecomsjournal.github.io/authors/policies/)?*
+
+*How does the article address the specific reviewer criteria for each article type?* These criteria are listed in the sections for author policies for [Best Practices](https://livecomsjournal.github.io/authors/policies/best_practices/#review-criteria), [Perpetual Reviews](https://livecomsjournal.github.io/authors/policies/perpetual_reviews/#review-criteria), [Tutorials](https://livecomsjournal.github.io/authors/policies/tutorials/#review-criteria),[Comparisons of Computational Software](https://livecomsjournal.github.io/authors/policies/compare_simulations/#review-criteria), and [Lessons Learned](https://livecomsjournal.github.io/authors/policies/lessons_learned/#review-criteria).
+
+*What other comments do you have for the author?*
+
+*What other comments do you have for the editor?* (The response to this question will not be seen by the authors)

--- a/_editorial_policies/03_reviewer_information.md
+++ b/_editorial_policies/03_reviewer_information.md
@@ -7,121 +7,30 @@ excerpt: Information for reviewers
 permalink: /policies/reviewer_information/
 ---
 
-This provides information relevant to reviewers of LiveCoMS, as well as a copy of the form letters that we typically use when corresponding with reviewers.
-
-
 ## Brief overview of the review process
 
 Before sending manuscripts for review, a lead editor of the relevant LiveCoMS section will have responded favorably to a [presubmission inquiry](https://livecomsjournal.github.io/authors/policies/#presubmission-letter) and then checked that the submitted manuscript indeed conforms to what was originally proposed.
 A LiveCoMS editor will also have checked that the manuscript appears to be reasonably well edited and ready for review.
-Given this preparation, LiveCoMS asks that reviewers respond promptly to review requests and take immediate action on reviewing manuscripts; typically we ask that reviews be returned within 14 days, though exceptions can be made in some cases.
+Given this preparation, LiveCoMS asks that reviewers respond promptly to review requests and take immediate action on reviewing manuscripts; typically we ask that reviews be returned within 21 days.
+
 The review process is in general similar to typical journals, in that we seek to ensure manuscripts are of high quality and will provide significant benefits to the field.
-However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.
-Additionally, consistent with its pedagogical mission, LiveCoMS requires a student review of each manuscript.
-We also have a Conflict of Interest policy and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
+However, we do also have specific [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and we ask reviewers to make sure they are aware of these, including [category-specific review criteria](https://livecomsjournal.github.io/authors/policies/#types-of-articles) relevant to the particular category of article.  Look in each section for the bullet pointed list of review criteria to consider, and respond to each of the relevant points specifically. Additionally, consistent with its pedagogical mission, LiveCoMS requires a graduate student or postdoc review of each manuscript.
 
-One potentially unique aspect of the LiveCoMS review process is the opportunity to engage with authors publicly rather than anonymously if you so desire.
+We also have a [Conflicts of Interest policy](https://livecomsjournal.github.io/policies/livecoms_bylaws/#conflicts-of-interest) and reviewers should make sure they are familiar with this and decline to review if they have a conflict, or if they are uncertain, to disclose any potential conflicts to the editor managing the review process.
+
+One unique aspect of the LiveCoMS review process is the opportunity to engage with authors publicly rather than anonymously if you so desire.
 Specifically, if you (as a reviewer) are interested in participating public discussion of the work and helping to improve it, you are free to comment on the issue tracker connected to the GitHub repository associated with the article, which can be a way to work together with the community to help authors improve their article.
-If you choose to do this, you are welcome to cross-reference GitHub comments in your review for LiveCoMS.
+If you choose to do this, it is suggested that you cross-reference GitHub comments in your review for LiveCoMS in an unambiguous way so the author knows exactly what needs to be addressed.  If you wish to remain completely anonymous, we suggest refraining from leaving GitHub comments near the time of your review, as the author will likely be able to guess your identity from the comments.
 
 
-Because we are attempting to make LiveCoMS as open as possible, we provide examples below of typical form letters used for correspondence with reviewers.
+A key purpose of the articles is that they should be useful to a range of researchers, but especially beginning researchers.
+Thus, all submitted manuscripts will be reviewed by a member of the student review board, which consists of graduate students and postdocs invited by the editorial board.
 
-## Reviewer letters
+Authors are also encouraged to have other researchers review their content, with comments and responses handled via the article's GitHub issue tracker.  
+A history of revisions in response to community concerns will impact the review process favorably.
 
-### Sample review request letter
+Reviewers will also be asked to assess whether articles are well edited and clearly written.
+Authors whose article uses inconsistent style or poor grammar, or is poorly edited, may be asked to revise and address these issues.
 
-Dear XYZ,
+Reviews will also consider the additional factors according to manuscript category: [please see the individual category links](#types-of-articles) for more information on these review criteria.
 
-We invite you to review the article indicated below, which has been submitted to the `YYY` category of the [Living Journal of Computational Molecular Science](http://livecomsjournal.org) (LiveCoMS).
-LiveCoMS is a brand new and rather unique journal, which focuses on promoting best practices in molecular computation via updateable educational articles of various kinds - tutorials, reviews, best-practices “manuals” and “lessons learned” articles.
-The journal is low-cost, non-profit and run by members of our community in a transparent way; in part, it aims to provide academic credit for important work that often goes unrewarded.
-One unique feature of the review process is the requirement for a student review of every article.
-
-To ACCEPT: `link`
-To DECLINE: `link`
-
-Reviews are generally expected within 14 days, although extra time may be allowable upon request.
-
-Please be sure you review and understand our conflict of interest policies before making a decision on whether or not to accept this review request.
-
-If you have any questions, please reply to this email.
-
-Thank you very much.
-`{{SENDER-FULL-NAME}}`, Associate Editor
-
-`{{MANUSCRIPT-TITLE}}`
-Abstract:
-(abstract will be automatically included)
-
-
-### Sample review action/thanks for agreeing letter
-
-(Each category has its own form letter, differing in the link to category-specific review criteria. The below sample is for Best Practices Guides)
-
-Dear XYZ,
-
-Thank you very much for agreeing to review the LiveCoMS submission, `{{MANUSCRIPT-TITLE}}`.
-Your support of our new community-run journal is very encouraging.
-
-I would appreciate receiving your review within 10 days, by `TTTTTT`.
-
-The article is to be considered under the `YYY` category.
-To aid you in your review, both the general [review criteria](https://livecomsjournal.github.io/authors/policies/#review-criteria) and the criteria specific to [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/) are appended below.
-
-Please read our conflict-of-interest criteria and inform me of any potential conflicts.
-
-Note also that non-anonymous feedback can be provided directly to authors via the GitHub page linked in the manuscript, if you so desire.
-
-If you have any questions, please reply to this email.
-
-Thank you very much.
-`{{SENDER-FULL-NAME}}`, Associate Editor
-
-REVIEW CRITERIA
-`Fill in current general review criteria`
-`Fill in current category-specific review criteria`
-
-### Reviewer ranking questions
-
-(All fields will be communicated to the authors except comments to the editor)
-- Overall rating (one to five stars, with five being best)
-- For this manuscript I recommend (Accept/Revise and resubmit/Reject)
-- How well does the manuscript meet overall review criteria and category-specific criteria?
-- Is the paper adequately edited for clear scientific English?
-- Given that the accepted PDF will be the final version of the manuscript, are there formatting, style, or quality issues which should be addressed before acceptance? What about the quality of the figures, layout of any tables, etc.?
-- Comments to the editor
-
-
-## Sample decision letters
-
-
-### Minor revisions
-
-Following is a sample decision letter which might be used for communicating the outcome of the review process to the authors.
-
-Dear `{{AUTHOR-FULL-NAME}}`,
-
-Thank you very much for your submission of your article, `{{MANUSCRIPT-TITLE}}`, to the Living Journal of Computational Molecular Sciences.
-We are delighted to inform you that we anticipate being able to accept your article, pending satisfactory completion of minor revisions as recommended by the reviewers (and detailed below).
-To facilitate the re-review of your manuscript, please submit a PDF version with *highlighted* changes, such as via [latexdiff](https://www.sharelatex.com/blog/2013/02/16/using-latexdiff-for-marking-changes-to-tex-documents.html).
-A final unhighlighted, publication-ready version will be requested should your manuscript be accepted.
-As you make the recommended changes, we also encourage you to make a final check that:
-- The article is well edited and all images and tables are of high quality and well laid out
-- Your final submitted PDF is in fact how you want your article to appear in its final version, as the journal does not typeset or alter the formatting of your article
-- Your GitHub repository is in order and ready to accept feedback from readers
-
-Thank you again for joining with us in this exciting new publishing enterprise!
-
-Sincerely,
-`{{SENDER-FULL-NAME}}`
-
-### More significant revisions
-
-(Same letter as the above, but with the following type of language instead)
-
-""...Your manuscript was judged to have significant merit and may ultimately be suitable for publication, but significant revisions are required. Please see the reviewer comments below." [continue with same letter as for minor]
-
-### Rejection
-
-"Unfortunately, we will not be able to accept your manuscript for publication. [editor should insert note here about whether manuscript was outside scope of journal, not of suitable quality, or otherwise inappropriate]..."


### PR DESCRIPTION
Reorganized reviewer info to:

* Create a specific page for reviewer information
* Put the contents of the reviewer form into that page
* Move the details of review process out of the author policies and into the reviewer instruction page.
* Move the letter text to journal_information where they can be discussed there (see https://github.com/livecomsjournal/journal_information/pull/69).

This supercedes #142 