### PR TITLE
Modification of voting procedures

### DIFF
--- a/_editorial_policies/01_bylaws.md
+++ b/_editorial_policies/01_bylaws.md
@@ -59,12 +59,17 @@ either Managing Editors or Associate Editors.
     1. At the time the bylaws are adopted, initial terms for the three Managing Editors will be for two, three, and four years, determined by mutual agreement or (pseudo-)random chance if no agreement is reached.
 1. Voting
     1. All votes described in the bylaws are tallied based on the fraction
-       of the Editorial Board responding within one week written notice
-       via e-mail or other voting mechanism approved by the Managing
-       Editors. In exceptional circumstances advance notice may be given
-       of a rush decision, where the board may be given one week (or more)
-       notice that their votes will be needed within a shorter window,
+       of the Editorial Board responding via e-mail or other voting mechanism
+       approved by the Managing Editors.
+    1. The standard voting period is one week following written notice. In
+       exceptional circumstances advance notice may be given of a rush decision,
+       where the board will be given at least three days notice that their
+       votes will be needed within a shorter timeframe,
        such as a 12 hour window.
+    1. Unless otherwise stated in the text of a motion, the Recording Secretary
+       may declare a vote closed prior to the end of the voting period
+       if at least two-thirds of the board members have voted
+       and the outcome of the motion cannot be altered by the receipt of additional votes.
 
 ## III. Conflicts of interest
 1. A potential "conflict of interest" is a circumstance which might affect one's ability to provide a fair and objective evaluation of a work, or which might reasonably be seen as having a likelihood of doing so by an independent outside observer.


### PR DESCRIPTION
Two changes to the bylaws:
1. Remove brackets around [Conflict of interest] in the bylaws. _Are they supposed to be there?_

2. Modify voting procedures:

    a) Allow the Secretary to terminate a vote early if both 2/3 of board members have voted **and** the vote outcome cannot change, unless the motion states otherwise. The purpose here is to not hold up business because the vote has to stay open for one week (per the current bylaws), even though the outcome of the vote cannot change. The restriction of "unless the motion states otherwise" gives us an option to ensure that a vote is held for one week (or more) if there is a desire for unanimity, 100% voting, or some other social reason.

    b) Shorten the notification period for rush decisions (e.g., have to vote within 12 hours) to three days. The notification period had been "one week (or more)", but I think this is too long if we need to make a rush decision, hence the reduction to three days. **This is a point for discussion - maybe three days is too short.** Maybe it needs to be four days to cover the case of notification on a Friday before a Monday holiday.