### PR TITLE
Add link to 'following acceptance' section

### DIFF
--- a/_editorial_policies/02_editor_instructions.md
+++ b/_editorial_policies/02_editor_instructions.md
@@ -49,7 +49,8 @@ Once an editor has handled the pre-review steps described above, the review proc
 - Makes a recommendation regarding acceptance, acceptance with minor or major revision, or rejection (keeping in mind the content of the presubmission letter), and communicates this recommendation to the Lead Editor who makes a final decision. Normally the Lead Editor will follow the handling editor's recommendations, but this process is helpful since the Lead will have approved the presubmission letter and thus needs to be involved if a less than favorable decision is to be made.
 - If the decision is that the authors must revise, provides appropriate direction (with the Lead Editor) about which comments to address if needed
 
-Following acceptance, the usual procedure is:
+## Following acceptance
+Following acceptance, the procedure is:
 - Have the author do a final check for issues with grammar, word choice, spelling, formatting (including issues with the LaTeX template, placement of figures, etc.) and typos, as normally would be done at the proofs stage. You may assist with this as well if you like.
 - Have the author enable the LiveCoMS footer by including the 'pubversion' class option in the document preamble, fill in the '\datereceived' and '\dateaccepted' fields, and provide a recompiled PDF for posting to the editor handling the submission and a managing editor..
 - Have a managing editor post the PDF as an ASAP article


### PR DESCRIPTION
Adding link to following acceptance section to make it easier to link from the author instructions section.