### PR TITLE
requiring prior publications for tutorial software

### DIFF
--- a/_author_instructions/05_tutorials.md
+++ b/_author_instructions/05_tutorials.md
@@ -16,7 +16,7 @@ These additional materials may include
   - a website with training information and downloadable Jupyter notebooks teaching users how to perform a modeling task
   - a more extensive online course-like format with recorded lectures.
   
-Tutorials must involve only software that has been previously validated through one or more peer-reviewed publications, and those must be referenced in the presubmission letter.  Often, one of the software developers will be one of the tutorial authors.  In some cases, other users will have sufficient expertise to provide the highest-quality tutorials expected for LiveCoMS. If no developer is a proposed author of the tutorial, the presubmission letter should provide sufficient argument why the authors' expertise is right for the tutorial. 
+Tutorials must involve only software that has been previously validated through one or more peer-reviewed publications, and those must be referenced in the presubmission letter.  Often, one of the software developers will be a tutorial author.  In some cases, other users will have sufficient expertise to provide the highest-quality tutorials expected for LiveCoMS. If no developer is a proposed author of the tutorial, the presubmission letter should provide sufficient argument why the authors' expertise is right for the tutorial. 
 
 **Scope of tutorials**: Tutorials should endeavor to cover a specific task or set of tasks at hand with explicit instructions, rather than cover too much information in a less detailed manner. However, they should also highlight how the steps might need to be modified, or additional care might need to be taken at particular points, to handle more general cases.  
 

--- a/_author_instructions/05_tutorials.md
+++ b/_author_instructions/05_tutorials.md
@@ -24,7 +24,7 @@ The scope of the tutorial, as well as the expected proficiencies / outcomes for 
 
 **Prerequisites for tutorials**: Tutorials should clearly define what concepts or abilities researchers will need to complete the tutorial (e.g., some proficiency in Python; experience with Jupyter notebooks; knowledge of classical MD; etc).
 
-Tutorials should clearly define what system and/or software requirements the researcher will need to complete the tutorial (e.g., VMD version 1.9 or newer, AMBER, etc.). Tutorials requiring specific software packages must provide instructions and files for the referenced version of the software, as well as any information that might affect the output (e.g., what precision the binaries were compiled, what machines they were compiled on). 
+Tutorials should clearly define what system and/or software requirements the researcher will need to complete the tutorial (e.g., VMD version 1.9 or newer, AMBER, etc.). Tutorials requiring specific software packages must provide instructions and files for the referenced version of the software, as well as any information that might affect the output (e.g., what precision the binaries were compiled, what machines they were compiled on). As mentioned above, the software must have beeen previously published and validated, as the goal of a tutorial is not to introduce newly-developed software but to facilitate others' using an established piece of software to carry out a particular task.
 
 **Pre-existing tutorials**: The submission of existing tutorials, so long as they meet the journal standards described here, is explicitly welcomed.
 Our goal is to encourage the development of high quality tutorials by providing some degree of academic credit for these important and time-consuming efforts.

--- a/_author_instructions/05_tutorials.md
+++ b/_author_instructions/05_tutorials.md
@@ -14,7 +14,9 @@ Tutorials are accompanied by associated other materials which help the reader pu
 These additional materials may include 
   - web pages with walkthroughs or instructional materials and downloadable files to work with
   - a website with training information and downloadable Jupyter notebooks teaching users how to perform a modeling task
-  - a more extensive online course-like format with recorded lectures.  
+  - a more extensive online course-like format with recorded lectures.
+  
+Tutorials must involve only software that has been previously validated through one or more peer-reviewed publications, and those must be referenced in the presubmission letter.  Often, one of the software developers will be one of the tutorial authors.  In some cases, other users will have sufficient expertise to provide the highest-quality tutorials expected for LiveCoMS. If no developer is a proposed author of the tutorial, the presubmission letter should provide sufficient argument why the authors' expertise is right for the tutorial. 
 
 **Scope of tutorials**: Tutorials should endeavor to cover a specific task or set of tasks at hand with explicit instructions, rather than cover too much information in a less detailed manner. However, they should also highlight how the steps might need to be modified, or additional care might need to be taken at particular points, to handle more general cases.  
 


### PR DESCRIPTION
Just wanted to make it clear that tutorials should only use software that has been previously validated/published.  