### PR TITLE
Minimize github.io About page

### DIFF
--- a/_about_livecoms/index.md
+++ b/_about_livecoms/index.md
@@ -15,9 +15,7 @@ practices in molecular modeling and simulation. These works are living
 documents, regularly updated with community input, and can include
 perpetual updated reviews, tutorials, comparisons between software
 packages, and other documents which aim to improve the studies in the
-field and require ongoing updates.
-
-**Sustainability**: We believe our model for LiveCoMS will ensure the journal's longevity and have significant impact on the field, and have budgeted and planned accordingly. However, as this is a publishing experiment, we are taking several safeguards to ensure research published with LiveCoMS is available for posterity. First, authors retain ownership over their work and control of their GitHub repository, allowing them to reuse it however they see fit, and archive it in any way they like. Second, the University of California library system has agreed to archive each year's publications from LiveCoMS in their eScholarship online repository, ensuring the material is archived for the long term in a way which is independent of our publishing model. 
+field and require ongoing updates.  See the main [About page](https://www.livecomsjournal.org/about) for more info.
 
 {% for collection in site.collections %}
   {% if collection.label == "about_livecoms" %}


### PR DESCRIPTION
There is additional content being auto-added based on labels at the bottom of the file, but I didn't want to mess with that.  Remove it?