### PR TITLE
Adding links for donations

### DIFF
--- a/_about_livecoms/04_donations.md
+++ b/_about_livecoms/04_donations.md
@@ -1,0 +1,48 @@
+---
+layout: single
+sidebar:
+  nav: donations.md
+title: Donating to LiveCoMS 
+excerpt: How to donate to LiveCoMS
+permalink: /about/donations
+---
+
+We very much appreciate financial donations to LiveCoMS! Donations are
+  to CU Boulder, the official publisher, to a fund exclusively for the
+  use of LiveCoMS and controlled by the managing editors.
+
+  <p><a href="https://giving.cu.edu/fund/living-journal-computational-molecular-science-support-fund" class="btn ">Donate Now!</a></p>
+
+* You can also support LiveCoMS by:
+  * Contributing to LiveCoMS articles
+  * Expressing your interest in becoming a reviewer (early career or otherwise)
+  * Providing feedback on GitHub repositories to improve later versions of LiveCoMS articles.
+  * Citing LiveCoMS articles that you use in your research.
+  * Spreading the word about LiveCoMS to your colleagues, mentors, and students.
+
+* Financial costs for LiveCoMS
+
+* LiveCoMS runs a very lean budget in order to keep costs for
+  contributors low.  Managing editors and editorial board members
+  receive no money from LiveCoMS.  Our current costs are:
+
+  * $1200/year for journal hosting by Scholastica (http://www.scholasticahq.com).
+  * $250/year for reviewer services by Scholastica.
+  * $504/year for Google Suites hosting of email and collaboratative office software
+
+  The main sources of income for LiveCOMS are donations and article
+  charges. We in particular appreciate seed funding provided by CU
+  Boulder Libraries, as well as continuing in-kind contributions by
+  managing DOI submissions and journal metadata. Article charges are
+  $100 for each article upon submission, from which we recieve about
+  $87 after charges from Scholastica and processing fees.
+
+If we raise more money through donations than cover our costs, we will work to:
+  * Hiring web developers and designers to support better tex templates and the website
+  * Investigate advertising options to better raise awareness of the journal and its purposes. 
+  * Hire copy editors to assist in final journal submissions 
+  * Waiving submission fees in part (based on need) or in whole.
+  * Buffer for future financial issues.
+  
+
+

--- a/_about_livecoms/04_donations.md
+++ b/_about_livecoms/04_donations.md
@@ -14,7 +14,7 @@ permalink: /about/donations
   official publisher of the journal, to a fund exclusively for use of
   LiveCoMS and controlled by the managing editors. The CU Foundation
   is a 501(c)(3) charitable organization, and donations are thus
-  usually tax-deductible.
+  generally tax-deductible for the purposes of U.S. taxes.
  
 Follow the link felow to donate:
 
@@ -41,8 +41,7 @@ are:
 
 The main sources of income for LiveCoMS are donations and article
 charges. We in particular appreciate seed funding provided by [CU
-Boulder Libraries](https://www.colorado.edu/libraries/), as well as continuing in-kind contributions by
-managing DOI submissions and journal metadata. Article charges are
+Boulder Libraries](https://www.colorado.edu/libraries/), as well as continuing support with management of DOIs and journal metadata. Article charges are
 $100 for each article upon submission, from which we receive about
 $80 after charges from Scholastica and processing fees.
 
@@ -50,5 +49,5 @@ If we raise more money through donations than cover our costs, we will work to:
   * Hire web developers and designers to support better .tex templates and improvements to the website
   * Investigate advertising options to better raise awareness of the journal and its purposes. 
   * Hire copy editors to assist in final journal submissions
-  * Waiving submission fees in part (based on need) or in whole.
+  * Waive submission fees in part (based on need) or in whole.
   * Create a buffer for future financial issues.

--- a/_about_livecoms/04_donations.md
+++ b/_about_livecoms/04_donations.md
@@ -21,7 +21,7 @@ You can also support LiveCoMS by:
   * Spreading the word about LiveCoMS to your colleagues, mentors, and students.
 
 
-###Financial costs for LiveCoMS
+### Financial costs for LiveCoMS
 
 LiveCoMS runs a very lean budget in order to keep costs for
 contributors low.  Managing editors and editorial board members

--- a/_about_livecoms/04_donations.md
+++ b/_about_livecoms/04_donations.md
@@ -7,42 +7,41 @@ excerpt: How to donate to LiveCoMS
 permalink: /about/donations
 ---
 
-We very much appreciate financial donations to LiveCoMS! Donations are
-  to CU Boulder, the official publisher, to a fund exclusively for the
-  use of LiveCoMS and controlled by the managing editors.
+  We very much appreciate financial donations to LiveCoMS! Donations are made
+  to the University of Colorado Boulder, the official publisher of the journal, to a fund exclusively for the
+  use of LiveCoMS and controlled by the managing editors. Follow the link below to donate:
 
   <p><a href="https://giving.cu.edu/fund/living-journal-computational-molecular-science-support-fund" class="btn ">Donate Now to LiveCoMS!</a></p>
 
-* You can also support LiveCoMS by:
+You can also support LiveCoMS by:
   * Contributing to LiveCoMS articles.
   * Expressing your interest in becoming a reviewer ([early career](/about/earlycareer) or otherwise).
   * Providing feedback on GitHub repositories for published articles to improve later versions of LiveCoMS articles.
   * Citing LiveCoMS articles that you use in your research.
   * Spreading the word about LiveCoMS to your colleagues, mentors, and students.
 
-* Financial costs for LiveCoMS
 
-* LiveCoMS runs a very lean budget in order to keep costs for
-  contributors low.  Managing editors and editorial board members
-  receive no money from LiveCoMS.  Our current costs are:
+###Financial costs for LiveCoMS
 
-  * $1200/year for journal hosting by [Scholastica](http://www.scholasticahq.com).
-  * $250/year for reviewer services by [Scholastica](http://www.scholasticahq.com)..
-  * $504/year for Google Suites hosting of email and collaboratative office software
+LiveCoMS runs a very lean budget in order to keep costs for
+contributors low.  Managing editors and editorial board members
+receive no money or reimbursement from LiveCoMS.  Our current costs
+are:
 
-  The main sources of income for LiveCOMS are donations and article
-  charges. We in particular appreciate seed funding provided by [CU
-  Boulder Libraries](https://www.colorado.edu/libraries/), as well as continuing in-kind contributions by
-  managing DOI submissions and journal metadata. Article charges are
-  $100 for each article upon submission, from which we recieve about
-  $87 after charges from Scholastica and processing fees.
+* $1200/year for journal hosting by [Scholastica](http://www.scholasticahq.com).
+* $250/year for reviewer services by [Scholastica](http://www.scholasticahq.com).
+* $504/year for Google Suites hosting of email and collaborative office software
+
+The main sources of income for LiveCoMS are donations and article
+charges. We in particular appreciate seed funding provided by [CU
+Boulder Libraries](https://www.colorado.edu/libraries/), as well as continuing in-kind contributions by
+managing DOI submissions and journal metadata. Article charges are
+$100 for each article upon submission, from which we receive about
+$80 after charges from Scholastica and processing fees.
 
 If we raise more money through donations than cover our costs, we will work to:
-  * Hiring web developers and designers to support better .tex templates and improvements to the website
+  * Hire web developers and designers to support better .tex templates and improvements to the website
   * Investigate advertising options to better raise awareness of the journal and its purposes. 
   * Hire copy editors to assist in final journal submissions
   * Waiving submission fees in part (based on need) or in whole.
-  * Buffer for future financial issues.
-  
-
-
+  * Create a buffer for future financial issues.

--- a/_about_livecoms/04_donations.md
+++ b/_about_livecoms/04_donations.md
@@ -11,12 +11,12 @@ We very much appreciate financial donations to LiveCoMS! Donations are
   to CU Boulder, the official publisher, to a fund exclusively for the
   use of LiveCoMS and controlled by the managing editors.
 
-  <p><a href="https://giving.cu.edu/fund/living-journal-computational-molecular-science-support-fund" class="btn ">Donate Now!</a></p>
+  <p><a href="https://giving.cu.edu/fund/living-journal-computational-molecular-science-support-fund" class="btn ">Donate Now to LiveCoMS!</a></p>
 
 * You can also support LiveCoMS by:
-  * Contributing to LiveCoMS articles
-  * Expressing your interest in becoming a reviewer (early career or otherwise)
-  * Providing feedback on GitHub repositories to improve later versions of LiveCoMS articles.
+  * Contributing to LiveCoMS articles.
+  * Expressing your interest in becoming a reviewer ([early career](/about/earlycareer) or otherwise).
+  * Providing feedback on GitHub repositories for published articles to improve later versions of LiveCoMS articles.
   * Citing LiveCoMS articles that you use in your research.
   * Spreading the word about LiveCoMS to your colleagues, mentors, and students.
 
@@ -26,21 +26,21 @@ We very much appreciate financial donations to LiveCoMS! Donations are
   contributors low.  Managing editors and editorial board members
   receive no money from LiveCoMS.  Our current costs are:
 
-  * $1200/year for journal hosting by Scholastica (http://www.scholasticahq.com).
-  * $250/year for reviewer services by Scholastica.
+  * $1200/year for journal hosting by [Scholastica](http://www.scholasticahq.com).
+  * $250/year for reviewer services by [Scholastica](http://www.scholasticahq.com)..
   * $504/year for Google Suites hosting of email and collaboratative office software
 
   The main sources of income for LiveCOMS are donations and article
-  charges. We in particular appreciate seed funding provided by CU
-  Boulder Libraries, as well as continuing in-kind contributions by
+  charges. We in particular appreciate seed funding provided by [CU
+  Boulder Libraries](https://www.colorado.edu/libraries/), as well as continuing in-kind contributions by
   managing DOI submissions and journal metadata. Article charges are
   $100 for each article upon submission, from which we recieve about
   $87 after charges from Scholastica and processing fees.
 
 If we raise more money through donations than cover our costs, we will work to:
-  * Hiring web developers and designers to support better tex templates and the website
+  * Hiring web developers and designers to support better .tex templates and improvements to the website
   * Investigate advertising options to better raise awareness of the journal and its purposes. 
-  * Hire copy editors to assist in final journal submissions 
+  * Hire copy editors to assist in final journal submissions
   * Waiving submission fees in part (based on need) or in whole.
   * Buffer for future financial issues.
   

--- a/_about_livecoms/04_donations.md
+++ b/_about_livecoms/04_donations.md
@@ -7,9 +7,16 @@ excerpt: How to donate to LiveCoMS
 permalink: /about/donations
 ---
 
-  We very much appreciate financial donations to LiveCoMS! Donations are made
-  to the University of Colorado Boulder, the official publisher of the journal, to a fund exclusively for the
-  use of LiveCoMS and controlled by the managing editors. Follow the link below to donate:
+### Donations to LiveCoMS
+
+  We very much appreciate financial donations to LiveCoMS! Donations
+  are made to the CU Foundation of University of Colorado Boulder, the
+  official publisher of the journal, to a fund exclusively for use of
+  LiveCoMS and controlled by the managing editors. The CU Foundation
+  is a 501(c)(3) charitable organization, and donations are thus
+  usually tax-deductible.
+ 
+Follow the link felow to donate:
 
   <p><a href="https://giving.cu.edu/fund/living-journal-computational-molecular-science-support-fund" class="btn ">Donate Now to LiveCoMS!</a></p>
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -186,6 +186,18 @@ policies_bylaws.md:
     - title: VI. Amendments
       url: /policies/livecoms_bylaws/index.html#vi-amendments
 
+donations.md:
+  - title: Donating to LiveCoMS
+    url: /about/donationsindex.html#
+    children:
+    - title: 
+      url: /about/donationsindex.html#
+      children:
+      - title: Donations to LiveCoMS
+        url: /about/donationsindex.html#donations-to-livecoms
+      - title: Financial costs for LiveCoMS
+        url: /about/donationsindex.html#financial-costs-for-livecoms
+
 thanks.md:
   - title: Thanks
     url: /about/thanks/index.html#


### PR DESCRIPTION
Please check over the text to see if it's phrased.  My local jekyll environment is broken, so I need to fix that and test how it looks, but please comment on the content, organization and placement of the material within the overall website.  The link from the main page is described here: https://github.com/livecomsjournal/journal_information/pull/79

I figure it is important to make the financing clear, so included that section. 