### PR TITLE
Updated navigation and title headings.

### DIFF
--- a/_author_instructions/05_tutorials.md
+++ b/_author_instructions/05_tutorials.md
@@ -2,8 +2,8 @@
 layout: single
 sidebar:
   nav: authors_tutorials.md
-title: Tutorials
-excerpt: What is a publishable tutorial?
+title: Tutorials and Training Articles
+excerpt: What is a publishable tutorial or training article?
 permalink: /authors/tutorials/
 ---
 

--- a/_author_instructions/index.md
+++ b/_author_instructions/index.md
@@ -9,7 +9,7 @@ header:
 excerpt: "Author instructions"
 ---
 
-LiveCoMS handles several different types of manuscripts including [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/), [Perpetual Reviews](https://livecomsjournal.github.io/authors/perpetual_reviews/), [Software Analyses](https://livecomsjournal.github.io/authors/software_analyses/), and [Tutorials](https://livecomsjournal.github.io/authors/tutorials/).
+LiveCoMS handles several different types of manuscripts including [Best Practices Guides](https://livecomsjournal.github.io/authors/best_practices/), [Perpetual Reviews](https://livecomsjournal.github.io/authors/perpetual_reviews/), [Software Analyses](https://livecomsjournal.github.io/authors/software_analyses/), and [Tutorials and Training Articles](https://livecomsjournal.github.io/authors/tutorials/).
 Authors wishing to submit to LiveCoMS should briefly review our [guidelines for authors](https://livecomsjournal.github.io/authors/policies/) and send a pre-submission inquiry to the appropriate [Lead Editor](http://www.livecomsjournal.org/editorial-board).
 Once this is approved, a brief overview of the process is as follows:
 - Prepare your manuscript in LaTeX using a suitable public GitHub repository, using our [LaTeX template](https://github.com/livecomsjournal/article_templates) appropriate for your article type, making sure you adhere to the relevant direction in our [General Author Instructions](https://livecomsjournal.github.io/authors/policies/) as well as the instructions specific to your article type (linked below).

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -110,15 +110,21 @@ authors_best_practices.md:
       url: /authors/best_practices/index.html#revision-schedule-for-best-practices-guides
 
 authors_tutorials.md:
-  - title: Tutorials
+  - title: Tutorials and Training Articles
     url: /authors/tutorials/index.html#
     children:
-    - title: What is a publishable tutorial?
-      url: /authors/tutorials/index.html#what-is-a-publishable-tutorial
+    - title: What is a publishable tutorial and/or training article?
+      url: /authors/tutorials/index.html#what-is-a-publishable-tutorial-andor-training-article
+    - title: Tutorials: Definition and scope
+      url: /authors/tutorials/index.html#tutorials-definition-and-scope
     - title: Additional criteria considered in the review of tutorials
       url: /authors/tutorials/index.html#additional-criteria-considered-in-the-review-of-tutorials
     - title: Revision schedule for tutorials
       url: /authors/tutorials/index.html#revision-schedule-for-tutorials
+    - title: Training articles: Definition and scope
+      url: /authors/tutorials/index.html#training-articles-definition-and-scope
+    - title: Additional criteria considered in the review of training articles
+      url: /authors/tutorials/index.html#additional-criteria-considered-in-the-review-of-training-articles
 
 authors_lessons_learned.md:
   - title: Lessons Learned


### PR DESCRIPTION
Update the headings to refer to training articles.  Note: I will also change the reference to "tutorials" in the article section to "tutorials and training articles" on the Scholastica page, see below.
<img width="349" alt="articles_list" src="https://user-images.githubusercontent.com/4274132/109177756-5fe19480-7745-11eb-968e-1048f466b462.png"> and 
<img width="306" alt="livecoms_menu" src="https://user-images.githubusercontent.com/4274132/109177788-6bcd5680-7745-11eb-989d-5504d36e857c.png">

