### PR TITLE
Allow for colons in navigation titles

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,218 +7,218 @@ main:
     url: /about/
 
 authors_software_analyses.md:
-  - title: Software Analyses
+  - title: "Software Analyses"
     url: /authors/software_analyses/index.html#
     children:
-    - title: What is a publishable software analysis paper for molecular simulation packages?
+    - title: "What is a publishable software analysis paper for molecular simulation packages?"
       url: /authors/software_analyses/index.html#what-is-a-publishable-software-analysis-paper-for-molecular-simulation-packages
-    - title: Additional criteria considered in review of software analysis papers
+    - title: "Additional criteria considered in review of software analysis papers"
       url: /authors/software_analyses/index.html#additional-criteria-considered-in-review-of-software-analysis-papers
-    - title: Revision schedule for software analyses
+    - title: "Revision schedule for software analyses"
       url: /authors/software_analyses/index.html#revision-schedule-for-software-analyses
 
 authors_policies.md:
-  - title: General Author Instructions
+  - title: "General Author Instructions"
     url: /authors/policies/index.html#
     children:
-    - title: Introduction
+    - title: "Introduction"
       url: /authors/policies/index.html#introduction
-    - title: General Article Guidelines
+    - title: "General Article Guidelines"
       url: /authors/policies/index.html#general-article-guidelines
-    - title: Types of Articles
+    - title: "Types of Articles"
       url: /authors/policies/index.html#types-of-articles
-  - title: Before Submission
+  - title: "Before Submission"
     url: /authors/policies/index.html#before-submission
     children:
-    - title: Presubmission Letter
+    - title: "Presubmission Letter"
       url: /authors/policies/index.html#presubmission-letter
-    - title: Preparation of Your Article For Submission
+    - title: "Preparation of Your Article For Submission"
       url: /authors/policies/index.html#preparation-of-your-article-for-submission
       children:
-      - title: Copyright license
+      - title: "Copyright license"
         url: /authors/policies/index.html#copyright-license
-      - title: Writing style and editing
+      - title: "Writing style and editing"
         url: /authors/policies/index.html#writing-style-and-editing
-      - title: Article layout
+      - title: "Article layout"
         url: /authors/policies/index.html#article-layout
-      - title: References
+      - title: "References"
         url: /authors/policies/index.html#references
-      - title: Figures
+      - title: "Figures"
         url: /authors/policies/index.html#figures
-      - title: Tables
+      - title: "Tables"
         url: /authors/policies/index.html#tables
-      - title: Error analysis
+      - title: "Error analysis"
         url: /authors/policies/index.html#error-analysis
-      - title: Preprints
+      - title: "Preprints"
         url: /authors/policies/index.html#preprints
-  - title: Submission and the Review Process
+  - title: "Submission and the Review Process"
     url: /authors/policies/index.html#submission-and-the-review-process
     children:
-    - title: Article submission
+    - title: "Article submission"
       url: /authors/policies/index.html#article-submission
-    - title: The review process
+    - title: "The review process"
       url: /authors/policies/index.html#the-review-process
-    - title: The revision process
+    - title: "The revision process"
       url: /authors/policies/index.html#the-revision-process
-    - title: Upon acceptance
+    - title: "Upon acceptance"
       url: /authors/policies/index.html#upon-acceptance
-  - title: Updating LiveCoMS Articles
+  - title: "Updating LiveCoMS Articles"
     url: /authors/policies/index.html#updating-livecoms-articles
     children:
-    - title: Engaging the Community in Improving Articles
+    - title: "Engaging the Community in Improving Articles"
       url: /authors/policies/index.html#engaging-the-community-in-improving-articles
-    - title: Paper Writing as Code Development
+    - title: "Paper Writing as Code Development"
       url: /authors/policies/index.html#paper-writing-as-code-development
-  - title: Authorship and Changes to Authorship
+  - title: "Authorship and Changes to Authorship"
     url: /authors/policies/index.html#authorship-and-changes-to-authorship
-  - title: Other Policies for Submitted Articles
+  - title: "Other Policies for Submitted Articles"
     url: /authors/policies/index.html#other-policies-for-submitted-articles
     children:
-    - title: Funding Compliance
+    - title: "Funding Compliance"
       url: /authors/policies/index.html#funding-compliance
-    - title: Licensing
+    - title: "Licensing"
       url: /authors/policies/index.html#licensing
-    - title: Prior Publication
+    - title: "Prior Publication"
       url: /authors/policies/index.html#prior-publication
-    - title: Author contributions and order
+    - title: "Author contributions and order"
       url: /authors/policies/index.html#author-contributions-and-order
-    - title: Abandoned Documents
+    - title: "Abandoned Documents"
       url: /authors/policies/index.html#abandoned-documents
 
 authors_perpetual_reviews.md:
-  - title: Perpetual Reviews
+  - title: "Perpetual Reviews"
     url: /authors/perpetual_reviews/index.html#
     children:
-    - title: What is a perpetual review?
+    - title: "What is a perpetual review?"
       url: /authors/perpetual_reviews/index.html#what-is-a-perpetual-review
-    - title: Additional review criteria for perpetual reviews
+    - title: "Additional review criteria for perpetual reviews"
       url: /authors/perpetual_reviews/index.html#additional-review-criteria-for-perpetual-reviews
-    - title: Revision schedule for perpetual reviews
+    - title: "Revision schedule for perpetual reviews"
       url: /authors/perpetual_reviews/index.html#revision-schedule-for-perpetual-reviews
 
 authors_best_practices.md:
-  - title: Best Practices Guides
+  - title: "Best Practices Guides"
     url: /authors/best_practices/index.html#
     children:
-    - title: What is a best practices guide?
+    - title: "What is a best practices guide?"
       url: /authors/best_practices/index.html#what-is-a-best-practices-guide
-    - title: Presubmission letter requirements
+    - title: "Presubmission letter requirements"
       url: /authors/best_practices/index.html#presubmission-letter-requirements
-    - title: Additional criteria considered in reviews of best practices guides
+    - title: "Additional criteria considered in reviews of best practices guides"
       url: /authors/best_practices/index.html#additional-criteria-considered-in-reviews-of-best-practices-guides
-    - title: Revision schedule for best practices guides
+    - title: "Revision schedule for best practices guides"
       url: /authors/best_practices/index.html#revision-schedule-for-best-practices-guides
 
 authors_tutorials.md:
-  - title: Tutorials and Training Articles
+  - title: "Tutorials and Training Articles"
     url: /authors/tutorials/index.html#
     children:
-    - title: What is a publishable tutorial and/or training article?
+    - title: "What is a publishable tutorial and/or training article?"
       url: /authors/tutorials/index.html#what-is-a-publishable-tutorial-andor-training-article
-    - title: Tutorials: Definition and scope
+    - title: "Tutorials: Definition and scope"
       url: /authors/tutorials/index.html#tutorials-definition-and-scope
-    - title: Additional criteria considered in the review of tutorials
+    - title: "Additional criteria considered in the review of tutorials"
       url: /authors/tutorials/index.html#additional-criteria-considered-in-the-review-of-tutorials
-    - title: Revision schedule for tutorials
+    - title: "Revision schedule for tutorials"
       url: /authors/tutorials/index.html#revision-schedule-for-tutorials
-    - title: Training articles: Definition and scope
+    - title: "Training articles: Definition and scope"
       url: /authors/tutorials/index.html#training-articles-definition-and-scope
-    - title: Additional criteria considered in the review of training articles
+    - title: "Additional criteria considered in the review of training articles"
       url: /authors/tutorials/index.html#additional-criteria-considered-in-the-review-of-training-articles
 
 authors_lessons_learned.md:
-  - title: Lessons Learned
+  - title: "Lessons Learned"
     url: /authors/lessons_learned/index.html#
     children:
-    - title: What is a "lesson learned" (i.e., negative results) document?
+    - title: "What is a \"lesson learned\" (i.e., negative results) document?"
       url: /authors/lessons_learned/index.html#what-is-a-lesson-learned-ie-negative-results-document
-    - title: Manuscript preparation instructions
+    - title: "Manuscript preparation instructions"
       url: /authors/lessons_learned/index.html#manuscript-preparation-instructions
-    - title: Additional critera considered in the review of lessons learned articles
+    - title: "Additional critera considered in the review of lessons learned articles"
       url: /authors/lessons_learned/index.html#additional-critera-considered-in-the-review-of-lessons-learned-articles
-    - title: Revision schedule for lessons learned documents
+    - title: "Revision schedule for lessons learned documents"
       url: /authors/lessons_learned/index.html#revision-schedule-for-lessons-learned-documents
 
 editor_instructions.md:
-  - title: Instructions for Editors
+  - title: "Instructions for Editors"
     url: /policies/editor_instructions/index.html#
     children:
-    - title: Workflow overview
+    - title: "Workflow overview"
       url: /policies/editor_instructions/index.html#workflow-overview
-    - title: Pre-submission letters
+    - title: "Pre-submission letters"
       url: /policies/editor_instructions/index.html#pre-submission-letters
-    - title: Pre-review processing
+    - title: "Pre-review processing"
       url: /policies/editor_instructions/index.html#pre-review-processing
       children:
-      - title: Lead Editor
+      - title: "Lead Editor"
         url: /policies/editor_instructions/index.html#lead-editor
-      - title: Associate Editor
+      - title: "Associate Editor"
         url: /policies/editor_instructions/index.html#associate-editor
-    - title: Review handling
+    - title: "Review handling"
       url: /policies/editor_instructions/index.html#review-handling
 
 reviewer_information.md:
-  - title: Information for Reviewers
+  - title: "Information for Reviewers"
     url: /policies/reviewer_information/index.html#
     children:
-    - title: Brief overview of the review process
+    - title: "Brief overview of the review process"
       url: /policies/reviewer_information/index.html#brief-overview-of-the-review-process
-    - title: Reviewer form
+    - title: "Reviewer form"
       url: /policies/reviewer_information/index.html#reviewer-form
 
 reviewing.md:
-  - title: Policies About Review of Manuscripts
+  - title: "Policies About Review of Manuscripts"
     url: /policies/reviewing/index.html#
     children:
-    - title: LiveCoMS review
+    - title: "LiveCoMS review"
       url: /policies/reviewing/index.html#livecoms-review
-    - title: Conflicts of interest
+    - title: "Conflicts of interest"
       url: /policies/reviewing/index.html#conflicts-of-interest
 
 policies_bylaws.md:
-  - title: Bylaws of the Living Journal of Computational Molecular Science
+  - title: "Bylaws of the Living Journal of Computational Molecular Science"
     url: /policies/livecoms_bylaws/index.html#
     children:
-    - title: I. Organization Title and Publication
+    - title: "I. Organization Title and Publication"
       url: /policies/livecoms_bylaws/index.html#i-organization-title-and-publication
-    - title: II. Editorial Board
+    - title: "II. Editorial Board"
       url: /policies/livecoms_bylaws/index.html#ii-editorial-board
-    - title: III. Conflicts of interest
+    - title: "III. Conflicts of interest"
       url: /policies/livecoms_bylaws/index.html#iii-conflicts-of-interest
-    - title: IV. Fraud and Plagiarism
+    - title: "IV. Fraud and Plagiarism"
       url: /policies/livecoms_bylaws/index.html#iv-fraud-and-plagiarism
-    - title: V. Review Process
+    - title: "V. Review Process"
       url: /policies/livecoms_bylaws/index.html#v-review-process
-    - title: VI. Amendments
+    - title: "VI. Amendments"
       url: /policies/livecoms_bylaws/index.html#vi-amendments
 
 donations.md:
-  - title: Donating to LiveCoMS
+  - title: "Donating to LiveCoMS"
     url: /about/donations/index.html#
     children:
-    - title: 
+    - title: ""
       url: /about/donations/index.html#
       children:
-      - title: Donations to LiveCoMS
+      - title: "Donations to LiveCoMS"
         url: /about/donations/index.html#donations-to-livecoms
-      - title: Financial costs for LiveCoMS
+      - title: "Financial costs for LiveCoMS"
         url: /about/donations/index.html#financial-costs-for-livecoms
 
 thanks.md:
-  - title: Thanks
+  - title: "Thanks"
     url: /about/thanks/index.html#
 
 earlycareer.md:
-  - title: For Students and Early Career Scientists
+  - title: "For Students and Early Career Scientists"
     url: /about/earlycareer/index.html#
 
 about_paper_code.md:
-  - title: Paper Writing as Code Development
+  - title: "Paper Writing as Code Development"
     url: /about/paper_code/index.html#
     children:
-    - title: Incentives
+    - title: "Incentives"
       url: /about/paper_code/index.html#incentives
-    - title: Tools for paper writing/code development
+    - title: "Tools for paper writing/code development"
       url: /about/paper_code/index.html#tools-for-paper-writingcode-development
-    - title: How it works in practice
+    - title: "How it works in practice"
       url: /about/paper_code/index.html#how-it-works-in-practice

--- a/generate_navigation.py
+++ b/generate_navigation.py
@@ -33,7 +33,10 @@ def make_link_from_heading(heading):
 
 def print_subtoc(headings, level, file_location):
     for h in headings:
-        print(level*2*' ' + '- title: ' + h['title'])
+        # We'll put the title between quotation marks to allow for colons,
+        # so we need to escape any quotation marks in the title
+        title = h['title'].replace('"', '\\"')
+        print(level*2*' ' + '- title: "' + title + '"')
         print(level*2*' ' + '  url: ' + file_location + h['ref'])
         if h['sub']:
             print(level*2*' ' + '  children:')


### PR DESCRIPTION
PR #205 broke the Jekyll navigation generation by adding colons in the
navigation file, which confuses the yml parsing. This is most easily
fixed by putting the headers used as navigation targets between
quotation marks.

This change modifies the python script generating the navigation to
always put navigation targers between quotation marks, and to escape
potential quotation marks already present in the string. It also
regenerates the navigation file.