### PR TITLE
Introduce Github action testing the webpage build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+# This action tries to build the webpage
+name: Test webpage build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+        bundler-cache: true  # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+# This file is used by the Github action testing the webpage build
+source 'https://rubygems.org'
+gem 'github-pages'


### PR DESCRIPTION
Suggesting to introduce a Github action that runs the webpage build to catch problems like #205. This action runs on pull requests and pushes to master, and simply checks whether the webpage can be built.

See https://github.com/ptmerz/livecomsjournal.github.io/pull/1 for an example: In that PR, I undid the fix in #206. The action catches this and blocks merging.

Moving forward, we can add more actions, e.g. automating the navigation generation (see #44, which I had totally forgotten about). But for now, this is an easy way to make sure that PRs don't break things.